### PR TITLE
Generate Ansible Playbook Role Tasks (#6)

### DIFF
--- a/internal/pkg/helm/templates/tasks/main.yml
+++ b/internal/pkg/helm/templates/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+########################################################################################
+# Create k8s resources for {{ name }}
+- name: Create resources for {{ name }} deployment
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item.name) | from_yaml }}"
+  loop:
+    {{{- range . }}}
+    - {{{ printf . }}}
+    {{{- end }}}

--- a/main.go
+++ b/main.go
@@ -24,5 +24,8 @@ func main() {
 	helm.SuppressWhitespaceTrimmingInTemplates(roleDirectory)
 	helm.ConvertControlFlowSyntax(roleDirectory)
 	helm.RemoveValuesReferencesInTemplates(roleDirectory)
+
+	// generate the task, which just renders the templates
+	helm.InstallAnsibleTasks(roleDirectory)
 }
 


### PR DESCRIPTION
Generates the eventual entrypoint for "ansible-playbook" to create the underlying
K8S resources.  This change involves creation of a task that just pipes in the
underlying templates (that have been translated to the best of our ability).

internal/pkg/helm.go was modified to utilize the upstream "text/template"
implementation.  That is to say, we are actually utilizing Go templates to
generate the Ansible Role Task's main.yml file.  That template file is located
in the internal/pkg/helm/templates/tasks/main.yml file.  If you take a quick
look at the file, you may notice that I utilized "{{{" and "}}}" delimiters for
the Go template configuration, as Ansible Playbook also utilizes "{{" and "}}"
delimiters by default, and I couldn't find a proper way to escape those.  Since
there are two template implementations, I decided to rename the entrypoint to
our forked one "j2template" to avoid confusion.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>