### PR TITLE
For loop changes

### DIFF
--- a/examples/helmcharts/nginx/values.yaml
+++ b/examples/helmcharts/nginx/values.yaml
@@ -195,9 +195,9 @@ ingress:
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  # - name: example.local-tls
-  #   key:
-  #   certificate:
+  - name: example.local-tls
+    key:
+    certificate:
 
 ## Prometheus Exporter / Metrics
 ##

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.0.2
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/fatih/color v1.9.0
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/protobuf v1.4.0 // indirect
 	github.com/onsi/ginkgo v1.12.0
@@ -17,7 +18,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
-	k8s.io/apimachinery v0.18.1 // indirect
+	k8s.io/apimachinery v0.18.1
 	k8s.io/helm v2.16.6+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/internal/pkg/helm/values_inspector.go
+++ b/internal/pkg/helm/values_inspector.go
@@ -5,10 +5,21 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/helm/pkg/chartutil"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
 const goTemplateMemberAccessOperator = "."
+
+//LogHelmReport - Collect Log data and print
+type LogHelmReport struct {
+	Name         string
+	NewLine      string
+	OriginalLine string
+	FieldName    string
+	Action       string
+	LineNumber   int
+}
 
 // HelmChartRef is a global variable.  This is not ideal, but it is necessary in this case in order to avoid a circular
 // dependency issue.  Essentially, the cmd package is originally responsible for determining the HelmChartRef via
@@ -39,7 +50,6 @@ func ArgIsLikelyBooleanYamlValue(arg string) (bool, error) {
 	return IsBooleanYamlValue(&chartMap, &pathArray)
 }
 
-
 // Determines whether path within the input context refers to a boolean type.  Consulting a Helm Chart's values is
 // helpful for determining whether a Helm Chart template conditional is checking for boolean equality v.s. definition.
 func IsBooleanYamlValue(input *map[string]interface{}, path *[]string) (bool, error) {
@@ -50,9 +60,8 @@ func IsBooleanYamlValue(input *map[string]interface{}, path *[]string) (bool, er
 		return false, errors.New("path slice must have at least one element")
 	}
 	// The recursive stopping condition is triggered when the pathIndex is equal to the indexCount (number of subpaths)
-	return isBooleanYamlValue(input, path, 0, len(*path) - 1)
+	return isBooleanYamlValue(input, path, 0, len(*path)-1)
 }
-
 
 // Internal recursive helper function that determines whether path within the input context refers to a boolean type.
 func isBooleanYamlValue(input *map[string]interface{}, path *[]string, pathIndex int, indexCount int) (bool, error) {
@@ -82,12 +91,156 @@ func isBooleanYamlValue(input *map[string]interface{}, path *[]string, pathIndex
 			// Handles the case in which an intermediary pathKey does not exist.  I.e., "metrics.doesntexist.lastkey".
 			if subMap != nil {
 				castedSubMap := subMap.(map[string]interface{})
-				return isBooleanYamlValue(&castedSubMap, path, pathIndex + 1, indexCount)
+				return isBooleanYamlValue(&castedSubMap, path, pathIndex+1, indexCount)
 			} else {
 				return false, errors.New("invalid path")
 			}
 		} else {
 			return false, errors.New("invalid path")
 		}
+	}
+}
+
+
+// GetValues takes a path that traverses a values that are stores in Values map and returns the value at the end of that path.
+// Given the following data the value at path "chapter.one.title" is "PR Review".
+//
+//	chapter:
+//	  one:
+//	    title: "PR Review"
+func GetValues(arg string) (*map[string][]*LogHelmReport, error) {
+	argString := strings.ReplaceAll(arg, ".Values.", "")
+	chartClient := NewChartClient()
+	err := chartClient.LoadChartFrom(HelmChartRef)
+	if err != nil {
+		logrus.Warnf("error loading chart: %s", err)
+		return nil, err
+	}
+	raw, _ := chartutil.ReadValues([]byte(chartClient.Chart.Values.Raw))
+	result, err := raw.PathValue(argString)
+	if err != nil {
+		logrus.Warnf("Path value not found for path : %s ", argString)
+		return nil, err
+	}
+	return dump(result), nil
+}
+
+// Converts and dumps the data of type interface{} slice
+// returned by chartUtil.GetPathValues into *map[string]interface{}
+func dump(result interface{}) *map[string][]*LogHelmReport {
+	items := reflect.ValueOf(result)
+	returnMap := make(map[string][]*LogHelmReport)
+	if items.Kind() == reflect.Slice {
+		for i := 0; i < items.Len(); i++ {
+			item := items.Index(i)
+			if item.Elem().Kind() == reflect.String {
+				returnMap[item.Interface().(string)] = []*LogHelmReport{}
+			} else if item.Elem().Kind() == reflect.Map {
+				returnMaps := item.Interface().(map[string]interface{})
+				for k := range returnMaps {
+					returnMap[k] = []*LogHelmReport{}
+				}
+			}
+		}
+	}
+	return &returnMap
+}
+
+// PreFixValuesWithItems...For single item list {% for item in hosts %}{{ item.name }}{% endfor %},
+// This function will prefix the list variables with a loop variable, within the body of the for loop.
+// There is two cases , one with field name that needs to be prefixed with loop variables
+// other condition is dot field name is replaced by loop variable
+func PreFixValuesWithItems(sb *strings.Builder, itemField string, pathValues *map[string][]*LogHelmReport) {
+	input := sb.String()
+	lines := strings.Split(string(input), "\n")
+	lineNumbers := []int{}
+	dotSuffixedField := " " + itemField + goTemplateMemberAccessOperator
+	sb.Reset()
+	for i, line := range lines {
+		for vars := range *pathValues {
+			if vars == goTemplateMemberAccessOperator { // if the replacing variable is dot then do this
+				re, err := regexp.Compile(`\s\.\s`)
+				if err == nil {
+					matched := re.MatchString(line)
+					if matched { //ignore line with template and includes
+						if strings.Contains(line, "template") || strings.Contains(line, "include") {
+							continue
+						}
+						lines[i] = re.ReplaceAllString(line, " "+itemField+" ")
+						logrus.Debugf("Replaced item %s  to : %s on line %d", vars, itemField, i)
+						r := new(LogHelmReport)
+						r.Action = vars + "Replaced with " + itemField + "\n"
+						r.NewLine = lines[i]
+						r.OriginalLine = line
+						r.FieldName = itemField
+						report := (*pathValues)[goTemplateMemberAccessOperator]
+						report = append(report, r)
+						(*pathValues)[goTemplateMemberAccessOperator] = report
+					}
+				}
+			} else {
+				re, err := regexp.Compile("\\s." + vars + "\\s")
+				if err == nil {
+					matched := re.MatchString(line)
+					if matched {
+						lines[i] = re.ReplaceAllString(line, dotSuffixedField+vars+" ")
+						logrus.Debugf("Appending item %s key to : %s on line %d", vars, dotSuffixedField+vars, i)
+						r := new(LogHelmReport)
+						r.Action = vars + " Replaced with " + itemField + "\n"
+						r.NewLine = lines[i]
+						r.OriginalLine = line
+						r.FieldName = itemField
+						report := (*pathValues)[goTemplateMemberAccessOperator]
+						report = append(report, r)
+						(*pathValues)[goTemplateMemberAccessOperator] = report
+					}
+				}
+			}
+			lineNumbers = append(lineNumbers, i)
+		}
+	}
+	if len(lineNumbers) > 0 {
+		logrus.Infof("Successfully updated references for range item field: %s on lines %d",
+			itemField, lineNumbers)
+	}
+	output := strings.Join(lines, "\n")
+	sb.WriteString(output)
+
+}
+
+// Remove $ from loop variables and body of the loop
+func RemoveDollarPrefix(sb *strings.Builder) {
+	input := sb.String()
+	lines := strings.Split(string(input), "\n")
+	lineNumbers := []int{}
+	sb.Reset()
+	re, err := regexp.Compile(`\$\b`)
+	if err != nil {
+		sb.WriteString(input)
+		logrus.Errorf("Error parsing dollar sign %#v", err)
+		return
+	}
+	for i, line := range lines {
+		matched := re.MatchString(line)
+		if matched {
+			lines[i] = re.ReplaceAllString(line, "")
+			logrus.Debugf("Removed `$`  prefix form variable %s on line %d", line, i)
+			lineNumbers = append(lineNumbers, i)
+		}
+	}
+	if len(lineNumbers) > 0 {
+		logrus.Infof("Successfully cleaned `$` from range fields on lines %d", lineNumbers)
+	}
+	output := strings.Join(lines, "\n")
+	sb.WriteString(output)
+}
+
+// LogReports - Printing report struct
+func PrintReportItems(reports []*LogHelmReport) {
+	for i, r := range reports {
+		logrus.Info(i, ".Action: ", r.Action)
+		logrus.Info(".Field Name: ", r.FieldName)
+		logrus.Info(".Original Line: ", r.OriginalLine)
+		logrus.Info(".New Line: ", r.NewLine)
 	}
 }

--- a/internal/pkg/text/template/parse/node_test.go
+++ b/internal/pkg/text/template/parse/node_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -17,7 +18,7 @@ type testCase struct {
 	chartDir string
 }
 
-var testCases = []testCase {
+var testCases = []testCase{
 	{
 		"basicconditionalchart_bool_case",
 		"testdata/basicconditionalchart_bool_case",
@@ -66,13 +67,15 @@ func TestToString(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error while parsing %s: %s", testFileName, err)
 			}
-			expectedFileName := path.Join(testCase.chartDir, testFileName + ".j2")
-			expected, err := ioutil.ReadFile(expectedFileName)
+			expectedFileName := path.Join(testCase.chartDir, testFileName+".j2")
+			expectedByte, err := ioutil.ReadFile(expectedFileName)
 			if err != nil {
 				t.Errorf("Could not load expected file: %s", expectedFileName)
 			}
-			actual := template.Root.String()
-			if string(expected) != actual {
+			expected := string(expectedByte)
+			expected = strings.TrimSpace(expected)
+			actual := strings.TrimSpace(template.Root.String())
+			if expected != actual {
 				t.Errorf("Parsing error.  Expected=%s Actual=%s", expected, actual)
 			}
 		}

--- a/internal/pkg/text/template/parse/testdata/nested_conditional/NestedConditional.yml.j2
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional/NestedConditional.yml.j2
@@ -4,7 +4,8 @@ condition1IsTrue
 {% endif %}
 {% else %}
 condition1IsFalse
-  {% range .Values.someList %}
-  {{ . }}
+  {% for item_someList in .Values.someKey.someList %}
+  {{ item_someList }}
   {% endfor %}
-{% endif %}
+{% endif %}{% for host in .Values.local.hosts %}{% for item_paths in .paths %}
+  - http://{{ host.name }}{{ item_paths }}{% endfor %}{% endfor %}

--- a/internal/pkg/text/template/parse/testdata/nested_conditional/templates/NestedConditional.yml
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional/templates/NestedConditional.yml
@@ -4,7 +4,12 @@ condition1IsTrue
 {{ end }}
 {{ else }}
 condition1IsFalse
-  {{ range .Values.someList }}
+  {{ range .Values.someKey.someList }}
   {{ . }}
   {{ end }}
 {{ end }}
+{{- range $host := .Values.local.hosts }}
+  {{- range .paths }}
+  - http://{{ $host.name }}{{ . }}
+  {{- end }}
+{{- end }}

--- a/internal/pkg/text/template/parse/testdata/nested_conditional/values.yaml
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional/values.yaml
@@ -6,3 +6,11 @@ someKey:
     - val2
     - val3
     - valN
+local:
+  hostname: example.local
+  hosts:
+   - name: example.local
+     path: /
+paths:
+  - rigth
+  - left

--- a/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/NestedConditionalWithIfDefinition.yml.j2
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/NestedConditionalWithIfDefinition.yml.j2
@@ -10,7 +10,8 @@ condition4IsNotDefinedButShouldAssumeDefinitionNotBool: {{ .Values.condition4IsD
 {% endif %}
 {% else %}
 condition1IsFalse
-  {% range .Values.someList %}
-  {{ . }}
-  {% endfor %}
+  {% for item_someList in .Values.someList %}
+  {{ item_someList }}
+  {% endfor %}{% for key, value in .Values.metrics.serviceMonitor.selector %}
+  {{ key }}: {{ value | quote }}{% endfor %}
 {% endif %}

--- a/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/templates/NestedConditionalWithIfDefinition.yml
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/templates/NestedConditionalWithIfDefinition.yml
@@ -13,4 +13,7 @@ condition1IsFalse
   {{ range .Values.someList }}
   {{ . }}
   {{ end }}
+  {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{ end }}

--- a/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/values.yaml
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/values.yaml
@@ -10,3 +10,7 @@ someKey:
 condition3IsDefined:
   key: val
   key2: val2
+metrics:
+  serviceMonitor:
+  selector:
+     prometheus: my-prometheus


### PR DESCRIPTION
This PR  converts range to for loop and prefixes right variables used within the loop via lookup on helm 
values 

> 

/*-------------------------------------------------------------------------------------------------------
         | INPUT                                  | LHS(vars) & RHS(cmds) |  OUTPUT                              |
          --------------------------------------------------------------------------------------------------------
         | *{{- range .Values.ingress.secrets }}   |       0 & 1          | {% for item_secrets in .Values.ingress.secrets }} |
         ----------------------------------------------------------------------------------------------------------
         | {{range $key, $value := ingress.annotations }}  | 2 & 1 | {% for $key, $value in ingress.annotations %}|
         -----------------------------------------------------------------------------------------------------------
         | {{- range $host := .Values.ingress.hosts }}  | 1 & 1 | {% for $host in .Values.ingress.hosts }}        |
         ----------------------------------------------------------------------------------------------------------
         | {{ range tuple "config1.toml" "config2.toml" "config3.toml" }} |0 & n |
         								{% for tuple "config1.toml" "config2.toml" "config3.toml" %}
          */
