### PR TITLE
Optionally install Ansible Filters for Sprig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ run:
 .PHONY: example
 example:
 		$(GOBUILD) -o $(BINARY_NAME) -v ./*.go
-		./$(BINARY_NAME) export $(ROLENAME) --helm-chart=$(HELM_EXAMPLE) --workspace=$(WORKSPACE)
+		./$(BINARY_NAME) export $(ROLENAME) --helm-chart=$(HELM_EXAMPLE) --workspace=$(WORKSPACE) --generateFilters=true

--- a/cmd/hamsible/export/cmd.go
+++ b/cmd/hamsible/export/cmd.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	helmChartRef  string
-	workspace     string
-	roleName      string
+	helmChartRef    string
+	workspace       string
+	roleName        string
+	generateFilters bool
 )
 
 func GetExportCmd() *cobra.Command {
@@ -26,7 +27,7 @@ func GetExportCmd() *cobra.Command {
 	}
 	exportCmd.Flags().StringVar(&helmChartRef, "helm-chart", "", "Path is downloaded helm chart folder.")
 	exportCmd.Flags().StringVar(&workspace, "workspace", "workspace", "workspace to generate exported ansible role.")
-
+	exportCmd.Flags().BoolVar(&generateFilters, "generateFilters", false,"whether or not to install Ansible Filter scaffolding")
 	return exportCmd
 }
 
@@ -68,6 +69,13 @@ func exportFunc(cmd *cobra.Command, args []string) error {
 	convert.RemoveValuesReferencesInTemplates(roleDirectory)
 	// generate the task, which just renders the templates
 	convert.InstallAnsibleTasks(roleDirectory)
+
+	// Since Sprig Ansible Filters are not fully implemented, generateFilters CLI argument controls whether or not to
+	// install the stub filters.
+	if generateFilters {
+		log.Info("Installing Sprig Ansible Filters")
+		convert.InstallAnsibleFilters(roleDirectory)
+	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Masterminds/sprig/v3 v3.0.2
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/fatih/color v1.9.0

--- a/internal/filters/invoke_go_tf.py
+++ b/internal/filters/invoke_go_tf.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+
+"""
+Module responsible for bridging Ansible Filters with Golang template functions.  This is a work in progress, and
+provided with the understanding that type-mapping is not really supported.  That is, this tool expects string I/O, and
+cannot handle Golang template or Sprig functions which return more complex data types (such as maps).
+
+Here is an example how to invoke the go "shuffle" template function from an Ansible Playbook:
+- debug:
+    msg:
+    - "{{ 'aaaaaaabbbbbbbbbccccccccddddddddd' | invoke_go_tf('shuffle') }}"
+
+Utilities to simplify this syntax are provided by the "_generic_wrapped_tf" method.  Two example implementations are
+"trim" and "contains".  Note:  these functions are commented out of the "filters" method, so they are not enabled by
+default.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+from typing import AnyStr
+from typing import Dict, Any, List
+
+
+class FilterModule(object):
+    """
+    FilterModule is an abstraction responsible for providing Golang Template and Sprig Function functionality through
+    an Ansible Playbook Filter.  This class will contain functionality that attempts to directly mimic existing Golang
+    template functionality to provide a 1:1 conversion when possible.
+    """
+
+    # Filter name constants
+    CONTAINS_KEY: str = "contains"
+    INVOKE_GO_TF__KEY: str = "invoke_go_tf"
+    TRIM__KEY: str = "trim"
+
+    # Other constants
+    ANSIBLE_ARGUMENT_ONE: int = 0
+    ANSIBLE_ARGUMENT_TWO: int = 1
+    ANSIBLE_ARGUMENT_THREE: int = 2
+    DEFAULT_ENCODING: str = "UTF-8"
+    GO_BINARY_NAME: str = "go"
+    GO_RUN_KEYWORD: str = "run"
+    SPRIG_CONDUIT_FILENAME: str = "main.go"
+    SPRIG_CONDUIT_PATH: AnyStr = os.path.join(os.path.dirname(__file__), SPRIG_CONDUIT_FILENAME)
+    ZERO_ARGS: int = 0
+
+    def __init__(self):
+        super(FilterModule, self).__init__()
+        # set up some defaults
+        self._log = self._setup_logging()
+        self._go_binary = self._establish_go_binary()
+
+    def _setup_logging(self) -> logging.Logger:
+        """
+        Sets up a logging.Logger equipped with a logging.StreamHandler, which will output log messages to the console.
+        :return: A preconfigured logging.Logger
+        """
+        self._log = logging.getLogger(__name__)
+        self._log.setLevel(logging.INFO)
+        self._log.addHandler(logging.StreamHandler())
+        return self._log
+
+    def _establish_go_binary(self):
+        """
+        Establish the go binary location within the system $PATH
+        :return: the file path location of the go binary
+        """
+        go_binary = shutil.which(FilterModule.GO_BINARY_NAME)
+        if go_binary is None:
+            self._log.error("Couldn't locate go binary in $PATH")
+        self._log.debug("Found go binary: %s", go_binary)
+        return go_binary
+
+    def filters(self) -> Dict[str, Any]:
+        """
+        Returns a list of exposed filters to the Ansible runtime.  Since Ansible provides no base class abstraction,
+        this method is assumed to be present, though it is not contractually obligated.
+        :return: a dict with keys that are the filter keywords and values are the filter implementation
+        """
+        # Uncomment those which make sense.
+        return {
+            # FilterModule.CONTAINS_KEY: self.contains,
+            FilterModule.INVOKE_GO_TF__KEY: self.invoke_go_tf,
+            # FilterModule.TRIM__KEY: self.trim,
+        }
+
+    def trim(self, *args) -> str:
+        """
+        A conduit between Ansible Filter and Go Sprig's "trim" function.  This invokes a Go subprocess with the
+        corresponding arguments and return the raw string output.
+
+        To enable, see "filters" function.
+
+        :param args: Ansible Playbook arguments
+        :return: subprocess output after rendering the Go template
+        """
+        return self._generic_wrapped_tf(FilterModule.TRIM__KEY, args)
+
+    def contains(self, *args) -> str:
+        """
+        A conduit between Ansible Filter and Go Sprig's "contains" function.  This invokes a Go subprocess with the
+        corresponding arguments and return the raw string output.
+
+        To enable, see "filters" function.
+
+        :param args: Ansible Playbook arguments
+        :return: subprocess output after rendering the Go template
+        """
+        return self._generic_wrapped_tf(FilterModule.CONTAINS_KEY, args)
+
+    @staticmethod
+    def _first_argument_exists(args: [str]) -> bool:
+        """
+        Verifies that the first Ansible Argument exists.  Since Ansible Filters are invoked by piping, the first
+        argument should always exist from this context;  this is considered a sanity check.
+        :param args: Ansible Playbook Filter arguments
+        :return: whether the first argument exists
+        """
+        return len(args) > FilterModule.ZERO_ARGS
+
+    def _generic_wrapped_tf(self, func_name: str, *args: [str]) -> str:
+        """
+        Provides an easy way to invoke Go templating for any generic Go/Sprig Template Function.  See "trim" and
+        "contains" for examples.
+        :param func_name: the name of the go template function
+        :param args: the Ansible Playbook Filter arguments
+        :return: the output after rendering the Go template
+        """
+        # The first argument is guaranteed to exist.  Check anyway;  weirder things have happened.
+        if not FilterModule._first_argument_exists(args=args):
+            self._log.error("Ansible Playbook should guarantee at least one argument;  check the input playbook")
+
+        # re-arrange arguments to expected format
+        arguments = args[FilterModule.ANSIBLE_ARGUMENT_ONE]
+        list_arguments = list(arguments)
+        augmented_args = list()
+        augmented_args.append(list_arguments[FilterModule.ANSIBLE_ARGUMENT_ONE])
+        augmented_args.append(func_name)
+        for i in range(FilterModule.ANSIBLE_ARGUMENT_TWO, len(list_arguments)):
+            augmented_args.append(list_arguments[i])
+        return self.invoke_go_tf(*augmented_args)
+
+    def invoke_go_tf(self, *args):
+        """
+        invokes a generic go template function.
+        :param args: Ansible Playbook Filter arguments
+        :return: the output after rendering the Go template
+        """
+        return self._invoke(args)
+
+    @staticmethod
+    def _form_system_call(go_binary: str, func_name: str, first_arg: str, other_args: List[str]) -> List[str]:
+        """
+        Form the system call used to invoke the Go template shim.
+        :param go_binary: the filename of the go binary
+        :param func_name: the name of the sprig/Go template function
+        :param first_arg: the first argument (the one before the pipe in Ansible filter)
+        :param other_args: all other arguments to the Sprig function
+        :return: the raw command array which can be passed to subprocess.Popen.
+        """
+        # re-arrange applicable arguments
+        sys_call_list = list()
+        sys_call_list.append(go_binary)
+        sys_call_list.append(FilterModule.GO_RUN_KEYWORD)
+        sys_call_list.append(FilterModule.SPRIG_CONDUIT_PATH)
+        sys_call_list.append(func_name)
+        # only shim in the first argument if it is not empty
+        if first_arg != "":
+            sys_call_list.append(first_arg)
+        for arg in other_args:
+            sys_call_list.append(str(arg))
+        return sys_call_list
+
+    def _invoke(self, args):
+        """
+        Invokes the Go subprocess with applicable arguments in order to resolve sprig function I/O.
+        :param args: Ansible Playbook Filter arguments.
+        :return: the output after rendering the Go template
+        """
+        self._log.info("_invoke%s", args)
+        first_arg = args[FilterModule.ANSIBLE_ARGUMENT_ONE]
+        func_name = args[FilterModule.ANSIBLE_ARGUMENT_TWO]
+        other_args = args[FilterModule.ANSIBLE_ARGUMENT_THREE:]
+
+        sys_call_list = FilterModule._form_system_call(self._go_binary, func_name, first_arg, other_args)
+        self._log.info("Go System Call: %s", " ".join(sys_call_list))
+
+        process = subprocess.Popen(sys_call_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout_bytes, stderr_bytes = process.communicate()
+        if stderr_bytes is not None and stderr_bytes.decode(FilterModule.DEFAULT_ENCODING) != "":
+            self._log.error("Go invocation attempt failed! stderr: %s",
+                            stderr_bytes.decode(FilterModule.DEFAULT_ENCODING))
+        stdout = stdout_bytes.decode(FilterModule.DEFAULT_ENCODING)
+        return stdout

--- a/internal/filters/main.go
+++ b/internal/filters/main.go
@@ -1,0 +1,118 @@
+/*
+A CLI->Go template shim used to render arbitrary sprig functions.
+
+To Run:
+> go run main.go sprigFunctionName sprigFunctionArguments...
+
+Example:
+> go run main.go trim "      some string      "
+
+This program takes textual input and attempts to resolve the sprigFunctionArguments types through inspecting
+sprigFunctionName's signature.  Bad input results in fatal exit with error code 1.  Debug output is intentionally
+suppressed as stdout is utilized by the calling program.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Masterminds/sprig"
+	"os"
+	"reflect"
+	"strconv"
+)
+
+const fatalExitReturnCode = 1
+const funcArgsCLIArgsFirstIndex = 2
+const funcNameCLIArgsIndex = 1
+const funcReturnOutputIndex = 0
+
+// Wrapper to call a Golang function through reflection.
+func CallFunc(funcMap map[string]interface{}, name string, arguments ... interface{}) (result []reflect.Value,
+	err error) {
+
+	function := reflect.ValueOf(funcMap[name])
+	if len(arguments) != function.Type().NumIn() {
+		err = errors.New("number of arguments is not adapted")
+		return
+	}
+	in := make([]reflect.Value, len(arguments))
+	for k, param := range arguments {
+		in[k] = reflect.ValueOf(param)
+	}
+	result = function.Call(in)
+	return
+}
+
+// Exits 1 with an appropriate message.
+func fatalError(message string) {
+	fmt.Fprintln(os.Stderr, "ERROR: " + message)
+	os.Exit(fatalExitReturnCode)
+}
+
+// Ensures that a sprig/template function was provided as a CLI argument.
+func checkForFuncName(args *[]string) {
+	if len(*args) < 2 {
+		fatalError("No Sprig Function name was provided")
+	}
+}
+
+// Extract a function given a funcMap.
+func extractFunction(funcMap map[string]interface{}, funcName string) (reflect.Value, error) {
+	functionInterface := funcMap[funcName]
+	if functionInterface == nil || reflect.TypeOf(functionInterface).Kind() != reflect.Func {
+		return reflect.Value{}, errors.New(funcName + " is not a valid function")
+	}
+	function := reflect.ValueOf(functionInterface)
+	return function, nil
+}
+
+
+
+// Invokes the CLI shim.  The first argument is the sprig/template function name.  The remaining arguments are the
+// sprig/template function arguments.
+func main() {
+	args := os.Args
+	// This would indicate a function with no funcName argument.
+	checkForFuncName(&args)
+
+	funcName := args[funcNameCLIArgsIndex]
+	funcArgs := args[funcArgsCLIArgsFirstIndex:]
+
+	// Loads only the text/template and Sprig Function Map.
+	funcMap := sprig.TxtFuncMap()
+
+	// Used to convert CLI args into functional arguments.
+	var iFuncArgs []interface{}
+	function, err := extractFunction(funcMap, funcName)
+
+	if err != nil {
+		fatalError(err.Error())
+	}
+
+	var argType = reflect.String
+	for i, b := range funcArgs {
+		// Attempt to derive the argument type from the method signature, and cast/convert the input appropriately.
+		if i < function.Type().NumIn() {
+			argType = function.Type().In(i).Kind()
+		}
+		// TODO: We must address other types of input when possible.
+		if argType == reflect.Int {
+			c, _ := strconv.Atoi(b)
+			iFuncArgs = append(iFuncArgs, c)
+		} else if argType == reflect.Uint32 {
+			c, _ := strconv.Atoi(b)
+			iFuncArgs = append(iFuncArgs, uint32(c))
+		} else {
+			iFuncArgs = append(iFuncArgs, b)
+		}
+	}
+
+	out, err := CallFunc(funcMap, funcName, iFuncArgs...)
+	if err != nil {
+		fatalError(err.Error())
+	}
+	// Note:  this is the only emission to stdout of the entire program
+	fmt.Print(out[funcReturnOutputIndex])
+}

--- a/internal/filters/sprig_ansible_filters.py
+++ b/internal/filters/sprig_ansible_filters.py
@@ -1,0 +1,494 @@
+#!/usr/bin/python
+
+"""
+Module stubbing out all Sprig Functions.  All function implementations just raise NotImplementedError.
+
+The naming convention for these functions is "sprig_<sprigFunctionName>".  Nothing is done to convert Go Template
+function names into Python function convention (i.e., conversion to snake case).  One should not name any additional
+functions with the prefix "sprig_" unless they are adding an additional Sprig function implementation.  The "filters"
+function returns keys without the "sprig_" prefix, so that Go Template functions that are referenced in Ansible
+Playbooks do not require the "sprig_" prefix.  For example:
+
+- debug:
+    msg:
+    - "{{ 'aaaaaaabbbbbbbbbccccccccddddddddd' | shuffle }}"
+"""
+
+import inspect
+
+
+class FilterModule(object):
+    """
+    Defines stub methods to implement Go template functions.
+    """
+
+    REPLACE_ONCE = 1
+    SPRIG_PREFIX = "sprig_"
+
+    def __init__(self):
+        super(FilterModule, self) .__init__()
+        # Any function in this class with a name that starts with the prefix "sprig_" is considered an Ansible Filter
+        # implementation.  As such, it is added to the private function map called self._ansible_filters
+        full_func_map = inspect.getmembers(FilterModule, predicate=inspect.isfunction)
+        self._ansible_filters = {}
+        for func_name, func in full_func_map:
+            if func_name.startswith(FilterModule.SPRIG_PREFIX):
+                ansible_filter_key = func_name.replace(FilterModule.SPRIG_PREFIX, "", FilterModule.REPLACE_ONCE)
+                self._ansible_filters[ansible_filter_key] = func
+
+    def filters(self):
+        """
+        Returns the dictionary of available filters.
+        :return: the dictionary of available filters.
+        """
+        return self._ansible_filters
+
+    def sprig_abbrev(self, *args):
+        raise NotImplementedError
+
+    def sprig_abbrevboth(self, *args):
+        raise NotImplementedError
+
+    def sprig_add(self, *args):
+        raise NotImplementedError
+
+    def sprig_add1(self, *args):
+        raise NotImplementedError
+
+    def sprig_adler32sum(self, *args):
+        raise NotImplementedError
+
+    def sprig_ago(self, *args):
+        raise NotImplementedError
+
+    def sprig_append(self, *args):
+        raise NotImplementedError
+
+    def sprig_atoi(self, *args):
+        raise NotImplementedError
+
+    def sprig_b32dec(self, *args):
+        raise NotImplementedError
+
+    def sprig_b32enc(self, *args):
+        raise NotImplementedError
+
+    def sprig_b64dec(self, *args):
+        raise NotImplementedError
+
+    def sprig_b64enc(self, *args):
+        raise NotImplementedError
+
+    def sprig_base(self, *args):
+        raise NotImplementedError
+
+    def sprig_biggest(self, *args):
+        raise NotImplementedError
+
+    def sprig_buildCustomCert(self, *args):
+        raise NotImplementedError
+
+    def sprig_camelcase(self, *args):
+        raise NotImplementedError
+
+    def sprig_cat(self, *args):
+        raise NotImplementedError
+
+    def sprig_ceil(self, *args):
+        raise NotImplementedError
+
+    def sprig_clean(self, *args):
+        raise NotImplementedError
+
+    def sprig_coalesce(self, *args):
+        raise NotImplementedError
+
+    def sprig_compact(self, *args):
+        raise NotImplementedError
+
+    def sprig_concat(self, *args):
+        raise NotImplementedError
+
+    def sprig_contains(self, *args):
+        raise NotImplementedError
+
+    def sprig_date(self, *args):
+        raise NotImplementedError
+
+    def sprig_dateInZone(self, *args):
+        raise NotImplementedError
+
+    def sprig_dateModify(self, *args):
+        raise NotImplementedError
+
+    def sprig_date_in_zone(self, *args):
+        raise NotImplementedError
+
+    def sprig_date_modify(self, *args):
+        raise NotImplementedError
+
+    def sprig_decryptAES(self, *args):
+        raise NotImplementedError
+
+    def sprig_deepCopy(self, *args):
+        raise NotImplementedError
+
+    def sprig_deepEqual(self, *args):
+        raise NotImplementedError
+
+    def sprig_default(self, *args):
+        raise NotImplementedError
+
+    def sprig_derivePassword(self, *args):
+        raise NotImplementedError
+
+    def sprig_dict(self, *args):
+        raise NotImplementedError
+
+    def sprig_dir(self, *args):
+        raise NotImplementedError
+
+    def sprig_div(self, *args):
+        raise NotImplementedError
+
+    def sprig_empty(self, *args):
+        raise NotImplementedError
+
+    def sprig_encryptAES(self, *args):
+        raise NotImplementedError
+
+    def sprig_env(self, *args):
+        raise NotImplementedError
+
+    def sprig_expandenv(self, *args):
+        raise NotImplementedError
+
+    def sprig_ext(self, *args):
+        raise NotImplementedError
+
+    def sprig_fail(self, *args):
+        raise NotImplementedError
+
+    def sprig_first(self, *args):
+        raise NotImplementedError
+
+    def sprig_float64(self, *args):
+        raise NotImplementedError
+
+    def sprig_floor(self, *args):
+        raise NotImplementedError
+
+    def sprig_genCA(self, *args):
+        raise NotImplementedError
+
+    def sprig_genPrivateKey(self, *args):
+        raise NotImplementedError
+
+    def sprig_genSelfSignedCert(self, *args):
+        raise NotImplementedError
+
+    def sprig_genSignedCert(self, *args):
+        raise NotImplementedError
+
+    def sprig_getHostByName(self, *args):
+        raise NotImplementedError
+
+    def sprig_has(self, *args):
+        raise NotImplementedError
+
+    def sprig_hasKey(self, *args):
+        raise NotImplementedError
+
+    def sprig_hasPrefix(self, *args):
+        raise NotImplementedError
+
+    def sprig_hasSuffix(self, *args):
+        raise NotImplementedError
+
+    def sprig_hello(self, *args):
+        raise NotImplementedError
+
+    def sprig_htmlDate(self, *args):
+        raise NotImplementedError
+
+    def sprig_htmlDateInZone(self, *args):
+        raise NotImplementedError
+
+    def sprig_indent(self, *args):
+        raise NotImplementedError
+
+    def sprig_initial(self, *args):
+        raise NotImplementedError
+
+    def sprig_initials(self, *args):
+        raise NotImplementedError
+
+    def sprig_int(self, *args):
+        raise NotImplementedError
+
+    def sprig_int64(self, *args):
+        raise NotImplementedError
+
+    def sprig_isAbs(self, *args):
+        raise NotImplementedError
+
+    def sprig_join(self, *args):
+        raise NotImplementedError
+
+    def sprig_kebabcase(self, *args):
+        raise NotImplementedError
+
+    def sprig_keys(self, *args):
+        raise NotImplementedError
+
+    def sprig_kindIs(self, *args):
+        raise NotImplementedError
+
+    def sprig_kindOf(self, *args):
+        raise NotImplementedError
+
+    def sprig_last(self, *args):
+        raise NotImplementedError
+
+    def sprig_list(self, *args):
+        raise NotImplementedError
+
+    def sprig_lower(self, *args):
+        raise NotImplementedError
+
+    def sprig_max(self, *args):
+        raise NotImplementedError
+
+    def sprig_merge(self, *args):
+        raise NotImplementedError
+
+    def sprig_mergeOverwrite(self, *args):
+        raise NotImplementedError
+
+    def sprig_min(self, *args):
+        raise NotImplementedError
+
+    def sprig_mod(self, *args):
+        raise NotImplementedError
+
+    def sprig_mul(self, *args):
+        raise NotImplementedError
+
+    def sprig_nindent(self, *args):
+        raise NotImplementedError
+
+    def sprig_nospace(self, *args):
+        raise NotImplementedError
+
+    def sprig_now(self, *args):
+        raise NotImplementedError
+
+    def sprig_omit(self, *args):
+        raise NotImplementedError
+
+    def sprig_pick(self, *args):
+        raise NotImplementedError
+
+    def sprig_pluck(self, *args):
+        raise NotImplementedError
+
+    def sprig_plural(self, *args):
+        raise NotImplementedError
+
+    def sprig_prepend(self, *args):
+        raise NotImplementedError
+
+    def sprig_push(self, *args):
+        raise NotImplementedError
+
+    def sprig_quote(self, *args):
+        raise NotImplementedError
+
+    def sprig_randAlpha(self, *args):
+        raise NotImplementedError
+
+    def sprig_randAlphaNum(self, *args):
+        raise NotImplementedError
+
+    def sprig_randAscii(self, *args):
+        raise NotImplementedError
+
+    def sprig_randNumeric(self, *args):
+        raise NotImplementedError
+
+    def sprig_regexFind(self, *args):
+        raise NotImplementedError
+
+    def sprig_regexFindAll(self, *args):
+        raise NotImplementedError
+
+    def sprig_regexMatch(self, *args):
+        raise NotImplementedError
+
+    def sprig_regexReplaceAll(self, *args):
+        raise NotImplementedError
+
+    def sprig_regexReplaceAllLiteral(self, *args):
+        raise NotImplementedError
+
+    def sprig_regexSplit(self, *args):
+        raise NotImplementedError
+
+    def sprig_repeat(self, *args):
+        raise NotImplementedError
+
+    def sprig_replace(self, *args):
+        raise NotImplementedError
+
+    def sprig_rest(self, *args):
+        raise NotImplementedError
+
+    def sprig_reverse(self, *args):
+        raise NotImplementedError
+
+    def sprig_round(self, *args):
+        raise NotImplementedError
+
+    def sprig_semver(self, *args):
+        raise NotImplementedError
+
+    def sprig_semverCompare(self, *args):
+        raise NotImplementedError
+
+    def sprig_set(self, *args):
+        raise NotImplementedError
+
+    def sprig_sha1sum(self, *args):
+        raise NotImplementedError
+
+    def sprig_sha256sum(self, *args):
+        raise NotImplementedError
+
+    def sprig_shuffle(self, *args):
+        raise NotImplementedError
+
+    def sprig_slice(self, *args):
+        raise NotImplementedError
+
+    def sprig_snakecase(self, *args):
+        raise NotImplementedError
+
+    def sprig_sortAlpha(self, *args):
+        raise NotImplementedError
+
+    def sprig_split(self, *args):
+        raise NotImplementedError
+
+    def sprig_splitList(self, *args):
+        raise NotImplementedError
+
+    def sprig_splitn(self, *args):
+        raise NotImplementedError
+
+    def sprig_squote(self, *args):
+        raise NotImplementedError
+
+    def sprig_sub(self, *args):
+        raise NotImplementedError
+
+    def sprig_substr(self, *args):
+        raise NotImplementedError
+
+    def sprig_swapcase(self, *args):
+        raise NotImplementedError
+
+    def sprig_ternary(self, *args):
+        raise NotImplementedError
+
+    def sprig_title(self, *args):
+        raise NotImplementedError
+
+    def sprig_toDate(self, *args):
+        raise NotImplementedError
+
+    def sprig_toDecimal(self, *args):
+        raise NotImplementedError
+
+    def sprig_toJson(self, *args):
+        raise NotImplementedError
+
+    def sprig_toPrettyJson(self, *args):
+        raise NotImplementedError
+
+    def sprig_toString(self, *args):
+        raise NotImplementedError
+
+    def sprig_toStrings(self, *args):
+        raise NotImplementedError
+
+    def sprig_trim(self, *args):
+        raise NotImplementedError
+
+    def sprig_trimAll(self, *args):
+        raise NotImplementedError
+
+    def sprig_trimPrefix(self, *args):
+        raise NotImplementedError
+
+    def sprig_trimSuffix(self, *args):
+        raise NotImplementedError
+
+    def sprig_trimall(self, *args):
+        raise NotImplementedError
+
+    def sprig_trunc(self, *args):
+        raise NotImplementedError
+
+    def sprig_tuple(self, *args):
+        raise NotImplementedError
+
+    def sprig_typeIs(self, *args):
+        raise NotImplementedError
+
+    def sprig_typeIsLike(self, *args):
+        raise NotImplementedError
+
+    def sprig_typeOf(self, *args):
+        raise NotImplementedError
+
+    def sprig_uniq(self, *args):
+        raise NotImplementedError
+
+    def sprig_unixEpoch(self, *args):
+        raise NotImplementedError
+
+    def sprig_unset(self, *args):
+        raise NotImplementedError
+
+    def sprig_until(self, *args):
+        raise NotImplementedError
+
+    def sprig_untilStep(self, *args):
+        raise NotImplementedError
+
+    def sprig_untitle(self, *args):
+        raise NotImplementedError
+
+    def sprig_upper(self, *args):
+        raise NotImplementedError
+
+    def sprig_urlJoin(self, *args):
+        raise NotImplementedError
+
+    def sprig_urlParse(self, *args):
+        raise NotImplementedError
+
+    def sprig_uuidv4(self, *args):
+        raise NotImplementedError
+
+    def sprig_values(self, *args):
+        raise NotImplementedError
+
+    def sprig_without(self, *args):
+        raise NotImplementedError
+
+    def sprig_wrap(self, *args):
+        raise NotImplementedError
+
+    def sprig_wrapWith(self, *args):
+        raise NotImplementedError

--- a/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/Chart.yaml
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: nested_conditional
+name: nested_conditional_with_if_definition
 version: 1.0.0
 appVersion: 1.0.0
 description: Contrived chart


### PR DESCRIPTION
Sprig Functions are Go template function abstractions used to
manipulate date in Go templating.  They are extremely useful for tasks
such as data format manipulation and entity creation (i.e., passwords
or certificates).  A fuller explanation of Sprig can be found here:

http://masterminds.github.io/sprig/

This change abstracts an internal package called "filters".  This
package is responsible for placing some stub Ansible Filters into the
generated Ansible Playbook skeleton in order to aid in transition from
Helm (Go Templating) to Ansible Playbook (Jinja2).  Notably, there are
two filters installed when "generateFilters" flag is true:
1) sprig_ansible_filters.py:  A complete stubbing of Ansible Playbook
Filters set up to mimic Sprig Function method signatures.  Right now,
every filter is instructed to raise NotImplementedError.
2) invoke_go_tf:  This is a more advanced set of filters aimed to demo
how one could wrap Go Template functions in order to provide a partial
replacement.  These filters demonstrate invoking the Go runtime from an
Ansible Filter context, and utilizing stdout to reference the rendered
template.  Right now, this is fairly limited as data inputs are mapped
from strings based on template function method signature (best effort)
and output is limited to strings.

This is not meant to be an all encompassing change, but rather just a
bit of tooling to help users in the conversion process.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>