### PR TITLE
Fix default file permissions

### DIFF
--- a/internal/pkg/convert/convert.go
+++ b/internal/pkg/convert/convert.go
@@ -25,7 +25,7 @@ const ansibleTasksTemplateLeftDelimiter = "{{{"
 const ansibleTasksTemplateLocation = "internal/pkg/helm/templates/tasks/main.yml"
 const ansibleTasksTemplateRightDelimiter = "}}}"
 const defaultDirectoryPermissions = 0777
-const defaultPermissions = 0600
+const defaultPermissions = 0660
 const filtersDirectory = "internal/filters"
 const helmDefaultsContainsSelfReference =
 	"# TODO: Replace \".Values.\" reference with a literal, as Ansible Playbook doesn't allow self-reference\n"


### PR DESCRIPTION
By default, files were instantiated using 0600 permissions.  This is
not correct and was found to lead to several issues, especially after
deploying in a container.  This change switches to utilize 0660 as a
default for new files.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>