### PR TITLE
Convert template function syntax to piped Jinja2 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,56 @@
-# Helm Ansible Template Exporter (WIP)
+# Helm Ansible Template Exporter
 
-This tool is aimed at automating the conversion from Helm to Ansible Playbook Role.  Based on the diverging operating
-models, some aspects of Helm charts are difficult or impossible to convert directly to Ansible Playbook roles.  This
-tool makes a best attempt to automatically convert a Helm chart into an Ansible Playbook Role.
+## Description
 
-Caveat Emptor:  This code is very much a work in progress.
+This tool automates conversion from Helm Chart to Ansible Playbook Role.  Helm Charts are defined utilizing Go
+templates, while Ansible Playbook Roles are defined using Yaml and Jinja2 templates.  Due to the fact that Go and Jinja2
+are completely separate languages, some facets of Helm charts are difficult or impossible to convert directly to
+Ansible Playbook roles.  This tool attempts to automatically convert a Helm chart into an Ansible Playbook Role, but
+some aspects of the conversion process must be performed manually by hand after utilizing this tool.
 
 ## Current Capabilities
 The current offering does the following:
-1) Creates a role in the "./workspace" directory using ansible-galaxy.
-2) Copies templates into the generated Ansible Playbook Role templates directory, renaming files with a ".j2" extension.
+1) Creates a role in the workspace directory using ansible-galaxy.
+2) Raw copies templates into the generated Ansible Playbook Role templates directory, renaming each template with a
+   ".j2" extension.
 3) Merges values.yml (or values.yaml) into the generated Ansible Playbook Role defaults/main.yml file.
 4) Searches the generated Ansible Playbook Role's defaults/main.yml file for self references (i.e., references to
-.Values.) and comments them out.  Ansible Playbook is incapable of expressing self references in defaults/main.yml,
-a clear technology gap between Ansible Playbook and Helm charts.  A "WARN" message is output indicating that a manual
-change is required to defaults/main.yml on the appropriate lines.
-5) Removes references to ".Values." in the generated Ansible Playbook's Roles' templates.  Ansible Playbook can directly
-reference the values in defaults/main.yml, so this reference is not needed.
+   .Values.) and comments them out.  Ansible Playbook is incapable of expressing self references in defaults/main.yml,
+   a clear technology gap between Ansible Playbook and Helm charts.  A "WARN" message is output indicating that a manual
+   change is required to defaults/main.yml on the appropriate lines.
+5) Convert Branch syntax for "if", "for" and "for key/value" in each template to utilize proper Jinja2 syntax.  This
+   includes a heuristic which attempts to determine if conditionals are checking for definition v.s. boolean evaluation.
+6) Convert boolean composition ordering.  Go Templating utilizes "and <condition1> <condition2>" format.  On the other
+   hand, Jinja2 utilizes "<condition1> and <condition2>" formatting.  helmExport handles this conversion automatically.
+7) Template functions invocations are converted to Jinja2 Ansible Filter invocations.  This requires converting direct
+   function invocations to piped invocations, as well as inserting the appropriate parentheses and commas for argument
+   lists.
+8) Removes references to ".Values." in the generated Ansible Playbook's Roles' templates.  Ansible Playbook can directly
+   reference the values in defaults/main.yml, so this reference isn't needed.
+9) If the "generateFilters" flag is set to true, some stub Ansible Filter implementations are installed for use in
+   converting Go template functions to Ansible Playbook Filters.
+
+## Known Limitations
+
+### Go/Sprig Template Function Limitations
+
+[Ansible Playbook Filter(s)](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html) are one
+candidate to replace Go/Sprig Template Functions.  However, they are not a direct 1:1 mapping, so a few extra steps must
+be taken after conversion.
+
+#### Implement or Replace Template Function Invocations with Ansible Filters
+There are a number of
+[Ansible Playbook Filters](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html) built directly
+into Ansible.  For instances where there does not seem to be a replacement, you will need to
+[create your own replacement](https://www.dasblinkenlichten.com/creating-ansible-filter-plugins/).  If you utilize the
+"generateFilters" command line argument, some example filters will be installed into your generated Ansible Playbook
+Role.
+
+### "template" and "include" are not supported
+
+Go Templates provide "template" and "include" in order to support dynamic template creation.  Ansible has no direct
+replacement, and although there are some similar constructs, helmExport currently doesn't support any conversion.
+Instead, consider using Ansible defaults as a replacement.
 
 ## Building
 
@@ -36,7 +70,8 @@ make clean
 ### Runtime Dependencies
 
 Helm Ansible Template Exporter requires [ansible-galaxy](https://galaxy.ansible.com/) to initialize exported roles.
-Additionally, ansible-galaxy must be included in the $PATH.
+Additionally, ansible-galaxy must be included in the $PATH.  Additionally, if you utilize the "generateFilters" flag,
+then a Go compiler must be installed.
 
 ### Run Instructions
 
@@ -44,3 +79,9 @@ Additionally, ansible-galaxy must be included in the $PATH.
 make run
 ``` 
 This will run the current implementation of code.
+
+Alternatively:
+
+```shell script
+./helmExport export nginx --helm-chart=./example --workspace=./workspace --generateFilters=true
+```

--- a/internal/pkg/text/template/parse/node_test.go
+++ b/internal/pkg/text/template/parse/node_test.go
@@ -35,6 +35,10 @@ var testCases = []testCase{
 		"nested_conditional_with_if_definition",
 		"testdata/nested_conditional_with_if_definition",
 	},
+	{
+		"basic_sprig",
+		"testdata/basic_sprig",
+	},
 }
 
 // Reads the files in a directory, exiting fatally if any errors occur.

--- a/internal/pkg/text/template/parse/testdata/basic_sprig/BasicSprig.yml.j2
+++ b/internal/pkg/text/template/parse/testdata/basic_sprig/BasicSprig.yml.j2
@@ -1,0 +1,10 @@
+labels:
+{{ .Values.labels | indent(.Values.indentValue) | squote }}
+{{ .Values.labels | quote | indent(6) }}
+{{ .Values.labels | toYaml | indent(4) }}
+
+somethingElse:
+  {{ hello }}
+
+car:
+  {{ .Values.someValue | toYaml('.') | quote | indent(8) }}

--- a/internal/pkg/text/template/parse/testdata/basic_sprig/Chart.yaml
+++ b/internal/pkg/text/template/parse/testdata/basic_sprig/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: basic_sprig
+version: 1.0.0
+appVersion: 1.0.0
+description: Contrived chart
+keywords:
+  - basic
+  - conditional
+  - basic helm chart
+home: http://127.0.0.1/
+icon: https://127.0.0.1/favicon.ico
+sources:
+  - https://127.0.0.1/basicconditional
+maintainers:
+  - name: none
+    email: none@127.0.0.1
+engine: gotpl

--- a/internal/pkg/text/template/parse/testdata/basic_sprig/templates/BasicSprig.yml
+++ b/internal/pkg/text/template/parse/testdata/basic_sprig/templates/BasicSprig.yml
@@ -1,0 +1,10 @@
+labels:
+{{ indent .Values.labels .Values.indentValue | squote }}
+{{ .Values.labels | quote | indent 6 }}
+{{ toYaml .Values.labels | indent 4 }}
+
+somethingElse:
+  {{ hello }}
+
+car:
+  {{ toYaml .Values.someValue '.' | quote | indent 8 }}

--- a/internal/pkg/text/template/parse/testdata/basic_sprig/values.yaml
+++ b/internal/pkg/text/template/parse/testdata/basic_sprig/values.yaml
@@ -1,0 +1,16 @@
+condition1:
+  key1: "tricked you, condition1 isn't even a condition at all"
+condition2: true
+someKey:
+  someList:
+    - val1
+    - val2
+    - val3
+    - valN
+condition3IsDefined:
+  key: val
+  key2: val2
+metrics:
+  serviceMonitor:
+  selector:
+     prometheus: my-prometheus


### PR DESCRIPTION
Jinja2 does not allow the following:
1) non-piped invocation
2) lack of parentheses/commas

This patch takes the Abstract Syntax Tree formed by the Go template engine
and converts the output to comply with the Jinja2 spec.  Expressions that
are non-piped are converted to utilize piped syntax.  Additionally, parens
and commas are inserted where appropriate.

A test case was added in order to demonstrate this new functionality.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>