### PR TITLE
Clean up the Node.writeTo(...) API Signature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GOGET=$(GOCMD) get
 BINARY_NAME=helmExport
 BINARY_UNIX=$(BINARY_NAME)_unix
 HELM_EXAMPLE=./examples/helmcharts/nginx/
-ROLENAME=ngnix
+ROLENAME=nginx
 WORKSPACE=workspace
 
 dependency:


### PR DESCRIPTION
Use an all-encompassing overloaded j2Context struct instead of
abstracting individual arguments for different "breadcrumbs".

Updates the documentation of node.go in order to further explain
our implementation choices, and the resulting limitations due
to those choices.

Fixes a small typo in the Makefile surrounding the default
example rolename.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>