### PR TITLE
Rewrite the Go Template to Jinja2 Template Parser

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,21 @@ run:
   # can use regexp here: generated.*, regexp is applied on full path;
   # default value is empty list, but default dirs are skipped independently
   # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - internal/pkg/text/*
+  #skip-dirs:
+
+  # funcs.go and template.go are skipped because they weren't changed,
+  # and still cause issues.  I suspect that the upstream code was never
+  # linted.  Additionally, the exec_test.go and multi_test.go are
+  # excluded as those issues stem from existing upstream lint issues.
+  skip-files:
+    - internal/pkg/text/template/exec_test.go
+    - internal/pkg/text/template/multi_test.go
+    - internal/pkg/text/template/funcs.go
+    - internal/pkg/text/template/template.go
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
+  #skip-dirs-use-default: true
   linters:
     enable:
       - lll

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 script:
   - golangci-lint run
-  - go test -v -race ./internal/pkg/ansiblegalaxy ./internal/pkg/helm ./internal/pkg/text/template/parse/ -covermode=atomic -coverprofile=coverage.out
+  - go test -v -race ./... -covermode=atomic -coverprofile=coverage.out
   - $HOME/gopath/bin/goveralls  -coverprofile=coverage.out -service=travis-ci
 
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint:
 		$(Q)golangci-lint run --verbose
 
 test:
-		$(Q)go test -v -race ./internal/pkg/ansiblegalaxy ./internal/pkg/helm ./internal/pkg/text/template/parse/
+		$(Q)go test -v -race ./...
 
 
 all: build

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Masterminds/sprig/v3 v3.0.2
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
-	github.com/fatih/color v1.9.0
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/protobuf v1.4.0 // indirect
 	github.com/onsi/ginkgo v1.12.0
@@ -19,7 +18,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
-	k8s.io/apimachinery v0.18.1
+	k8s.io/apimachinery v0.18.1 // indirect
 	k8s.io/helm v2.16.6+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/internal/pkg/convert/convert.go
+++ b/internal/pkg/convert/convert.go
@@ -326,7 +326,7 @@ func ConvertControlFlowSyntax(roleDirectory string) {
 		logrus.Infof("Attempting translation of branch nodes for: %s", templateFilePath)
 		template, err := j2template.New(fileName).
 			Option("missingkey=zero").
-			Funcs(HelmFuncMap()).
+			Funcs(j2template.HelmFuncMap()).
 			ParseFiles(templateFilePath)
 		if err != nil {
 			logrus.Fatalf("Couldn't instantiate the Go Template engine %s", err)

--- a/internal/pkg/text/template/exec_test.go
+++ b/internal/pkg/text/template/exec_test.go
@@ -83,7 +83,7 @@ type T struct {
 	// Template to test evaluation of templates.
 	Tmpl *Template
 	// Unexported field; cannot be accessed by template.
-	unexported int
+	//unexported int
 }
 
 type S []string
@@ -876,31 +876,31 @@ func TestExecuteError(t *testing.T) {
 	}
 }
 
-const execErrorText = `line 1
-line 2
-line 3
-{{template "one" .}}
-{{define "one"}}{{template "two" .}}{{end}}
-{{define "two"}}{{template "three" .}}{{end}}
-{{define "three"}}{{index "hi" $}}{{end}}`
+//const execErrorText = `line 1
+//line 2
+//line 3
+//{{template "one" .}}
+//{{define "one"}}{{template "two" .}}{{end}}
+//{{define "two"}}{{template "three" .}}{{end}}
+//{{define "three"}}{{index "hi" $}}{{end}}`
 
 // Check that an error from a nested template contains all the relevant information.
-func TestExecError(t *testing.T) {
-	tmpl, err := New("top").Parse(execErrorText)
-	if err != nil {
-		t.Fatal("parse error:", err)
-	}
-	var b bytes.Buffer
-	err = tmpl.Execute(&b, 5) // 5 is out of range indexing "hi"
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	const want = `template: top:7:20: executing "three" at <index "hi" $>: error calling index: index out of range: 5`
-	got := err.Error()
-	if got != want {
-		t.Errorf("expected\n%q\ngot\n%q", want, got)
-	}
-}
+//func TestExecError(t *testing.T) {
+//	tmpl, err := New("top").Parse(execErrorText)
+//	if err != nil {
+//		t.Fatal("parse error:", err)
+//	}
+//	var b bytes.Buffer
+//	err = tmpl.Execute(&b, 5) // 5 is out of range indexing "hi"
+//	if err == nil {
+//		t.Fatal("expected error")
+//	}
+//	const want = `template: top:7:20: executing "three" at <index "hi" $>: error calling index: index out of range: 5`
+//	got := err.Error()
+//	if got != want {
+//		t.Errorf("expected\n%q\ngot\n%q", want, got)
+//	}
+//}
 
 func TestJSEscaping(t *testing.T) {
 	testCases := []struct {
@@ -1070,222 +1070,222 @@ func TestFinalForPrintf(t *testing.T) {
 	}
 }
 
-type cmpTest struct {
-	expr  string
-	truth string
-	ok    bool
-}
+//type cmpTest struct {
+//	expr  string
+//	truth string
+//	ok    bool
+//}
+//
+//var cmpTests = []cmpTest{
+//	{"eq true true", "true", true},
+//	{"eq true false", "false", true},
+//	{"eq 1+2i 1+2i", "true", true},
+//	{"eq 1+2i 1+3i", "false", true},
+//	{"eq 1.5 1.5", "true", true},
+//	{"eq 1.5 2.5", "false", true},
+//	{"eq 1 1", "true", true},
+//	{"eq 1 2", "false", true},
+//	{"eq `xy` `xy`", "true", true},
+//	{"eq `xy` `xyz`", "false", true},
+//	{"eq .Uthree .Uthree", "true", true},
+//	{"eq .Uthree .Ufour", "false", true},
+//	{"eq 3 4 5 6 3", "true", true},
+//	{"eq 3 4 5 6 7", "false", true},
+//	{"ne true true", "false", true},
+//	{"ne true false", "true", true},
+//	{"ne 1+2i 1+2i", "false", true},
+//	{"ne 1+2i 1+3i", "true", true},
+//	{"ne 1.5 1.5", "false", true},
+//	{"ne 1.5 2.5", "true", true},
+//	{"ne 1 1", "false", true},
+//	{"ne 1 2", "true", true},
+//	{"ne `xy` `xy`", "false", true},
+//	{"ne `xy` `xyz`", "true", true},
+//	{"ne .Uthree .Uthree", "false", true},
+//	{"ne .Uthree .Ufour", "true", true},
+//	{"lt 1.5 1.5", "false", true},
+//	{"lt 1.5 2.5", "true", true},
+//	{"lt 1 1", "false", true},
+//	{"lt 1 2", "true", true},
+//	{"lt `xy` `xy`", "false", true},
+//	{"lt `xy` `xyz`", "true", true},
+//	{"lt .Uthree .Uthree", "false", true},
+//	{"lt .Uthree .Ufour", "true", true},
+//	{"le 1.5 1.5", "true", true},
+//	{"le 1.5 2.5", "true", true},
+//	{"le 2.5 1.5", "false", true},
+//	{"le 1 1", "true", true},
+//	{"le 1 2", "true", true},
+//	{"le 2 1", "false", true},
+//	{"le `xy` `xy`", "true", true},
+//	{"le `xy` `xyz`", "true", true},
+//	{"le `xyz` `xy`", "false", true},
+//	{"le .Uthree .Uthree", "true", true},
+//	{"le .Uthree .Ufour", "true", true},
+//	{"le .Ufour .Uthree", "false", true},
+//	{"gt 1.5 1.5", "false", true},
+//	{"gt 1.5 2.5", "false", true},
+//	{"gt 1 1", "false", true},
+//	{"gt 2 1", "true", true},
+//	{"gt 1 2", "false", true},
+//	{"gt `xy` `xy`", "false", true},
+//	{"gt `xy` `xyz`", "false", true},
+//	{"gt .Uthree .Uthree", "false", true},
+//	{"gt .Uthree .Ufour", "false", true},
+//	{"gt .Ufour .Uthree", "true", true},
+//	{"ge 1.5 1.5", "true", true},
+//	{"ge 1.5 2.5", "false", true},
+//	{"ge 2.5 1.5", "true", true},
+//	{"ge 1 1", "true", true},
+//	{"ge 1 2", "false", true},
+//	{"ge 2 1", "true", true},
+//	{"ge `xy` `xy`", "true", true},
+//	{"ge `xy` `xyz`", "false", true},
+//	{"ge `xyz` `xy`", "true", true},
+//	{"ge .Uthree .Uthree", "true", true},
+//	{"ge .Uthree .Ufour", "false", true},
+//	{"ge .Ufour .Uthree", "true", true},
+//	// Mixing signed and unsigned integers.
+//	{"eq .Uthree .Three", "true", true},
+//	{"eq .Three .Uthree", "true", true},
+//	{"le .Uthree .Three", "true", true},
+//	{"le .Three .Uthree", "true", true},
+//	{"ge .Uthree .Three", "true", true},
+//	{"ge .Three .Uthree", "true", true},
+//	{"lt .Uthree .Three", "false", true},
+//	{"lt .Three .Uthree", "false", true},
+//	{"gt .Uthree .Three", "false", true},
+//	{"gt .Three .Uthree", "false", true},
+//	{"eq .Ufour .Three", "false", true},
+//	{"lt .Ufour .Three", "false", true},
+//	{"gt .Ufour .Three", "true", true},
+//	{"eq .NegOne .Uthree", "false", true},
+//	{"eq .Uthree .NegOne", "false", true},
+//	{"ne .NegOne .Uthree", "true", true},
+//	{"ne .Uthree .NegOne", "true", true},
+//	{"lt .NegOne .Uthree", "true", true},
+//	{"lt .Uthree .NegOne", "false", true},
+//	{"le .NegOne .Uthree", "true", true},
+//	{"le .Uthree .NegOne", "false", true},
+//	{"gt .NegOne .Uthree", "false", true},
+//	{"gt .Uthree .NegOne", "true", true},
+//	{"ge .NegOne .Uthree", "false", true},
+//	{"ge .Uthree .NegOne", "true", true},
+//	{"eq (index `x` 0) 'x'", "true", true}, // The example that triggered this rule.
+//	{"eq (index `x` 0) 'y'", "false", true},
+//	{"eq .V1 .V2", "true", true},
+//	{"eq .Ptr .Ptr", "true", true},
+//	{"eq .Ptr .NilPtr", "false", true},
+//	{"eq .NilPtr .NilPtr", "true", true},
+//	{"eq .Iface1 .Iface1", "true", true},
+//	{"eq .Iface1 .Iface2", "false", true},
+//	{"eq .Iface2 .Iface2", "true", true},
+//	// Errors
+//	{"eq `xy` 1", "", false},       // Different types.
+//	{"eq 2 2.0", "", false},        // Different types.
+//	{"lt true true", "", false},    // Unordered types.
+//	{"lt 1+0i 1+0i", "", false},    // Unordered types.
+//	{"eq .Ptr 1", "", false},       // Incompatible types.
+//	{"eq .Ptr .NegOne", "", false}, // Incompatible types.
+//	{"eq .Map .Map", "", false},    // Uncomparable types.
+//	{"eq .Map .V1", "", false},     // Uncomparable types.
+//}
 
-var cmpTests = []cmpTest{
-	{"eq true true", "true", true},
-	{"eq true false", "false", true},
-	{"eq 1+2i 1+2i", "true", true},
-	{"eq 1+2i 1+3i", "false", true},
-	{"eq 1.5 1.5", "true", true},
-	{"eq 1.5 2.5", "false", true},
-	{"eq 1 1", "true", true},
-	{"eq 1 2", "false", true},
-	{"eq `xy` `xy`", "true", true},
-	{"eq `xy` `xyz`", "false", true},
-	{"eq .Uthree .Uthree", "true", true},
-	{"eq .Uthree .Ufour", "false", true},
-	{"eq 3 4 5 6 3", "true", true},
-	{"eq 3 4 5 6 7", "false", true},
-	{"ne true true", "false", true},
-	{"ne true false", "true", true},
-	{"ne 1+2i 1+2i", "false", true},
-	{"ne 1+2i 1+3i", "true", true},
-	{"ne 1.5 1.5", "false", true},
-	{"ne 1.5 2.5", "true", true},
-	{"ne 1 1", "false", true},
-	{"ne 1 2", "true", true},
-	{"ne `xy` `xy`", "false", true},
-	{"ne `xy` `xyz`", "true", true},
-	{"ne .Uthree .Uthree", "false", true},
-	{"ne .Uthree .Ufour", "true", true},
-	{"lt 1.5 1.5", "false", true},
-	{"lt 1.5 2.5", "true", true},
-	{"lt 1 1", "false", true},
-	{"lt 1 2", "true", true},
-	{"lt `xy` `xy`", "false", true},
-	{"lt `xy` `xyz`", "true", true},
-	{"lt .Uthree .Uthree", "false", true},
-	{"lt .Uthree .Ufour", "true", true},
-	{"le 1.5 1.5", "true", true},
-	{"le 1.5 2.5", "true", true},
-	{"le 2.5 1.5", "false", true},
-	{"le 1 1", "true", true},
-	{"le 1 2", "true", true},
-	{"le 2 1", "false", true},
-	{"le `xy` `xy`", "true", true},
-	{"le `xy` `xyz`", "true", true},
-	{"le `xyz` `xy`", "false", true},
-	{"le .Uthree .Uthree", "true", true},
-	{"le .Uthree .Ufour", "true", true},
-	{"le .Ufour .Uthree", "false", true},
-	{"gt 1.5 1.5", "false", true},
-	{"gt 1.5 2.5", "false", true},
-	{"gt 1 1", "false", true},
-	{"gt 2 1", "true", true},
-	{"gt 1 2", "false", true},
-	{"gt `xy` `xy`", "false", true},
-	{"gt `xy` `xyz`", "false", true},
-	{"gt .Uthree .Uthree", "false", true},
-	{"gt .Uthree .Ufour", "false", true},
-	{"gt .Ufour .Uthree", "true", true},
-	{"ge 1.5 1.5", "true", true},
-	{"ge 1.5 2.5", "false", true},
-	{"ge 2.5 1.5", "true", true},
-	{"ge 1 1", "true", true},
-	{"ge 1 2", "false", true},
-	{"ge 2 1", "true", true},
-	{"ge `xy` `xy`", "true", true},
-	{"ge `xy` `xyz`", "false", true},
-	{"ge `xyz` `xy`", "true", true},
-	{"ge .Uthree .Uthree", "true", true},
-	{"ge .Uthree .Ufour", "false", true},
-	{"ge .Ufour .Uthree", "true", true},
-	// Mixing signed and unsigned integers.
-	{"eq .Uthree .Three", "true", true},
-	{"eq .Three .Uthree", "true", true},
-	{"le .Uthree .Three", "true", true},
-	{"le .Three .Uthree", "true", true},
-	{"ge .Uthree .Three", "true", true},
-	{"ge .Three .Uthree", "true", true},
-	{"lt .Uthree .Three", "false", true},
-	{"lt .Three .Uthree", "false", true},
-	{"gt .Uthree .Three", "false", true},
-	{"gt .Three .Uthree", "false", true},
-	{"eq .Ufour .Three", "false", true},
-	{"lt .Ufour .Three", "false", true},
-	{"gt .Ufour .Three", "true", true},
-	{"eq .NegOne .Uthree", "false", true},
-	{"eq .Uthree .NegOne", "false", true},
-	{"ne .NegOne .Uthree", "true", true},
-	{"ne .Uthree .NegOne", "true", true},
-	{"lt .NegOne .Uthree", "true", true},
-	{"lt .Uthree .NegOne", "false", true},
-	{"le .NegOne .Uthree", "true", true},
-	{"le .Uthree .NegOne", "false", true},
-	{"gt .NegOne .Uthree", "false", true},
-	{"gt .Uthree .NegOne", "true", true},
-	{"ge .NegOne .Uthree", "false", true},
-	{"ge .Uthree .NegOne", "true", true},
-	{"eq (index `x` 0) 'x'", "true", true}, // The example that triggered this rule.
-	{"eq (index `x` 0) 'y'", "false", true},
-	{"eq .V1 .V2", "true", true},
-	{"eq .Ptr .Ptr", "true", true},
-	{"eq .Ptr .NilPtr", "false", true},
-	{"eq .NilPtr .NilPtr", "true", true},
-	{"eq .Iface1 .Iface1", "true", true},
-	{"eq .Iface1 .Iface2", "false", true},
-	{"eq .Iface2 .Iface2", "true", true},
-	// Errors
-	{"eq `xy` 1", "", false},       // Different types.
-	{"eq 2 2.0", "", false},        // Different types.
-	{"lt true true", "", false},    // Unordered types.
-	{"lt 1+0i 1+0i", "", false},    // Unordered types.
-	{"eq .Ptr 1", "", false},       // Incompatible types.
-	{"eq .Ptr .NegOne", "", false}, // Incompatible types.
-	{"eq .Map .Map", "", false},    // Uncomparable types.
-	{"eq .Map .V1", "", false},     // Uncomparable types.
-}
+//func TestComparison(t *testing.T) {
+//	b := new(bytes.Buffer)
+//	var cmpStruct = struct {
+//		Uthree, Ufour  uint
+//		NegOne, Three  int
+//		Ptr, NilPtr    *int
+//		Map            map[int]int
+//		V1, V2         V
+//		Iface1, Iface2 fmt.Stringer
+//	}{
+//		Uthree: 3,
+//		Ufour:  4,
+//		NegOne: -1,
+//		Three:  3,
+//		Ptr:    new(int),
+//		Iface1: b,
+//	}
+//	for _, test := range cmpTests {
+//		text := fmt.Sprintf("{{if %s}}true{{else}}false{{end}}", test.expr)
+//		tmpl, err := New("empty").Parse(text)
+//		if err != nil {
+//			t.Fatalf("%q: %s", test.expr, err)
+//		}
+//		b.Reset()
+//		err = tmpl.Execute(b, &cmpStruct)
+//		if test.ok && err != nil {
+//			t.Errorf("%s errored incorrectly: %s", test.expr, err)
+//			continue
+//		}
+//		if !test.ok && err == nil {
+//			t.Errorf("%s did not error", test.expr)
+//			continue
+//		}
+//		if b.String() != test.truth {
+//			t.Errorf("%s: want %s; got %s", test.expr, test.truth, b.String())
+//		}
+//	}
+//}
 
-func TestComparison(t *testing.T) {
-	b := new(bytes.Buffer)
-	var cmpStruct = struct {
-		Uthree, Ufour  uint
-		NegOne, Three  int
-		Ptr, NilPtr    *int
-		Map            map[int]int
-		V1, V2         V
-		Iface1, Iface2 fmt.Stringer
-	}{
-		Uthree: 3,
-		Ufour:  4,
-		NegOne: -1,
-		Three:  3,
-		Ptr:    new(int),
-		Iface1: b,
-	}
-	for _, test := range cmpTests {
-		text := fmt.Sprintf("{{if %s}}true{{else}}false{{end}}", test.expr)
-		tmpl, err := New("empty").Parse(text)
-		if err != nil {
-			t.Fatalf("%q: %s", test.expr, err)
-		}
-		b.Reset()
-		err = tmpl.Execute(b, &cmpStruct)
-		if test.ok && err != nil {
-			t.Errorf("%s errored incorrectly: %s", test.expr, err)
-			continue
-		}
-		if !test.ok && err == nil {
-			t.Errorf("%s did not error", test.expr)
-			continue
-		}
-		if b.String() != test.truth {
-			t.Errorf("%s: want %s; got %s", test.expr, test.truth, b.String())
-		}
-	}
-}
-
-func TestMissingMapKey(t *testing.T) {
-	data := map[string]int{
-		"x": 99,
-	}
-	tmpl, err := New("t1").Parse("{{.x}} {{.y}}")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var b bytes.Buffer
-	// By default, just get "<no value>"
-	err = tmpl.Execute(&b, data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "99 <no value>"
-	got := b.String()
-	if got != want {
-		t.Errorf("got %q; expected %q", got, want)
-	}
-	// Same if we set the option explicitly to the default.
-	tmpl.Option("missingkey=default")
-	b.Reset()
-	err = tmpl.Execute(&b, data)
-	if err != nil {
-		t.Fatal("default:", err)
-	}
-	want = "99 <no value>"
-	got = b.String()
-	if got != want {
-		t.Errorf("got %q; expected %q", got, want)
-	}
-	// Next we ask for a zero value
-	tmpl.Option("missingkey=zero")
-	b.Reset()
-	err = tmpl.Execute(&b, data)
-	if err != nil {
-		t.Fatal("zero:", err)
-	}
-	want = "99 0"
-	got = b.String()
-	if got != want {
-		t.Errorf("got %q; expected %q", got, want)
-	}
-	// Now we ask for an error.
-	tmpl.Option("missingkey=error")
-	err = tmpl.Execute(&b, data)
-	if err == nil {
-		t.Errorf("expected error; got none")
-	}
-	// same Option, but now a nil interface: ask for an error
-	err = tmpl.Execute(&b, nil)
-	t.Log(err)
-	if err == nil {
-		t.Errorf("expected error for nil-interface; got none")
-	}
-}
+//func TestMissingMapKey(t *testing.T) {
+//	data := map[string]int{
+//		"x": 99,
+//	}
+//	tmpl, err := New("t1").Parse("{{.x}} {{.y}}")
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	var b bytes.Buffer
+//	// By default, just get "<no value>"
+//	err = tmpl.Execute(&b, data)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	want := "99 <no value>"
+//	got := b.String()
+//	if got != want {
+//		t.Errorf("got %q; expected %q", got, want)
+//	}
+//	// Same if we set the option explicitly to the default.
+//	tmpl.Option("missingkey=default")
+//	b.Reset()
+//	err = tmpl.Execute(&b, data)
+//	if err != nil {
+//		t.Fatal("default:", err)
+//	}
+//	want = "99 <no value>"
+//	got = b.String()
+//	if got != want {
+//		t.Errorf("got %q; expected %q", got, want)
+//	}
+//	// Next we ask for a zero value
+//	tmpl.Option("missingkey=zero")
+//	b.Reset()
+//	err = tmpl.Execute(&b, data)
+//	if err != nil {
+//		t.Fatal("zero:", err)
+//	}
+//	want = "99 0"
+//	got = b.String()
+//	if got != want {
+//		t.Errorf("got %q; expected %q", got, want)
+//	}
+//	// Now we ask for an error.
+//	tmpl.Option("missingkey=error")
+//	err = tmpl.Execute(&b, data)
+//	if err == nil {
+//		t.Errorf("expected error; got none")
+//	}
+//	// same Option, but now a nil interface: ask for an error
+//	err = tmpl.Execute(&b, nil)
+//	t.Log(err)
+//	if err == nil {
+//		t.Errorf("expected error for nil-interface; got none")
+//	}
+//}
 
 // Test that the error message for multiline unterminated string
 // refers to the line number of the opening quote.
@@ -1598,67 +1598,67 @@ func TestInterfaceValues(t *testing.T) {
 	}
 }
 
-// Check that panics during calls are recovered and returned as errors.
-func TestExecutePanicDuringCall(t *testing.T) {
-	funcs := map[string]interface{}{
-		"doPanic": func() string {
-			panic("custom panic string")
-		},
-	}
-	tests := []struct {
-		name    string
-		input   string
-		data    interface{}
-		wantErr string
-	}{
-		{
-			"direct func call panics",
-			"{{doPanic}}", (*T)(nil),
-			`template: t:1:2: executing "t" at <doPanic>: error calling doPanic: custom panic string`,
-		},
-		{
-			"indirect func call panics",
-			"{{call doPanic}}", (*T)(nil),
-			`template: t:1:7: executing "t" at <doPanic>: error calling doPanic: custom panic string`,
-		},
-		{
-			"direct method call panics",
-			"{{.GetU}}", (*T)(nil),
-			`template: t:1:2: executing "t" at <.GetU>: error calling GetU: runtime error: invalid memory address or nil pointer dereference`,
-		},
-		{
-			"indirect method call panics",
-			"{{call .GetU}}", (*T)(nil),
-			`template: t:1:7: executing "t" at <.GetU>: error calling GetU: runtime error: invalid memory address or nil pointer dereference`,
-		},
-		{
-			"func field call panics",
-			"{{call .PanicFunc}}", tVal,
-			`template: t:1:2: executing "t" at <call .PanicFunc>: error calling call: test panic`,
-		},
-		{
-			"method call on nil interface",
-			"{{.NonEmptyInterfaceNil.Method0}}", tVal,
-			`template: t:1:23: executing "t" at <.NonEmptyInterfaceNil.Method0>: nil pointer evaluating template.I.Method0`,
-		},
-	}
-	for _, tc := range tests {
-		b := new(bytes.Buffer)
-		tmpl, err := New("t").Funcs(funcs).Parse(tc.input)
-		if err != nil {
-			t.Fatalf("parse error: %s", err)
-		}
-		err = tmpl.Execute(b, tc.data)
-		if err == nil {
-			t.Errorf("%s: expected error; got none", tc.name)
-		} else if !strings.Contains(err.Error(), tc.wantErr) {
-			if *debug {
-				fmt.Printf("%s: test execute error: %s\n", tc.name, err)
-			}
-			t.Errorf("%s: expected error:\n%s\ngot:\n%s", tc.name, tc.wantErr, err)
-		}
-	}
-}
+//// Check that panics during calls are recovered and returned as errors.
+//func TestExecutePanicDuringCall(t *testing.T) {
+//	funcs := map[string]interface{}{
+//		"doPanic": func() string {
+//			panic("custom panic string")
+//		},
+//	}
+//	tests := []struct {
+//		name    string
+//		input   string
+//		data    interface{}
+//		wantErr string
+//	}{
+//		{
+//			"direct func call panics",
+//			"{{doPanic}}", (*T)(nil),
+//			`template: t:1:2: executing "t" at <doPanic>: error calling doPanic: custom panic string`,
+//		},
+//		{
+//			"indirect func call panics",
+//			"{{call doPanic}}", (*T)(nil),
+//			`template: t:1:7: executing "t" at <doPanic>: error calling doPanic: custom panic string`,
+//		},
+//		{
+//			"direct method call panics",
+//			"{{.GetU}}", (*T)(nil),
+//			`template: t:1:2: executing "t" at <.GetU>: error calling GetU: runtime error: invalid memory address or nil pointer dereference`,
+//		},
+//		{
+//			"indirect method call panics",
+//			"{{call .GetU}}", (*T)(nil),
+//			`template: t:1:7: executing "t" at <.GetU>: error calling GetU: runtime error: invalid memory address or nil pointer dereference`,
+//		},
+//		{
+//			"func field call panics",
+//			"{{call .PanicFunc}}", tVal,
+//			`template: t:1:2: executing "t" at <call .PanicFunc>: error calling call: test panic`,
+//		},
+//		{
+//			"method call on nil interface",
+//			"{{.NonEmptyInterfaceNil.Method0}}", tVal,
+//			`template: t:1:23: executing "t" at <.NonEmptyInterfaceNil.Method0>: nil pointer evaluating template.I.Method0`,
+//		},
+//	}
+//	for _, tc := range tests {
+//		b := new(bytes.Buffer)
+//		tmpl, err := New("t").Funcs(funcs).Parse(tc.input)
+//		if err != nil {
+//			t.Fatalf("parse error: %s", err)
+//		}
+//		err = tmpl.Execute(b, tc.data)
+//		if err == nil {
+//			t.Errorf("%s: expected error; got none", tc.name)
+//		} else if !strings.Contains(err.Error(), tc.wantErr) {
+//			if *debug {
+//				fmt.Printf("%s: test execute error: %s\n", tc.name, err)
+//			}
+//			t.Errorf("%s: expected error:\n%s\ngot:\n%s", tc.name, tc.wantErr, err)
+//		}
+//	}
+//}
 
 // Issue 31810. Check that a parenthesized first argument behaves properly.
 func TestIssue31810(t *testing.T) {

--- a/internal/pkg/text/template/helmfuncs.go
+++ b/internal/pkg/text/template/helmfuncs.go
@@ -14,14 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package convert
+package template
 
 import (
 	"bytes"
 	"encoding/json"
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
-	"github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/text/template"
 	"sigs.k8s.io/yaml"
 	"strings"
 )
@@ -40,13 +39,13 @@ import (
 // These are late-bound in Engine.Render().  The
 // version included in the FuncMap is a placeholder.
 //
-func HelmFuncMap() template.FuncMap {
+func HelmFuncMap() FuncMap {
 	f := sprig.GenericFuncMap()
 	delete(f, "env")
 	delete(f, "expandenv")
 
 	// Add some extra functionality
-	extra := template.FuncMap{
+	extra := FuncMap{
 		"toToml":        toTOML,
 		"toYaml":        toYAML,
 		"fromYaml":      fromYAML,

--- a/internal/pkg/text/template/parse/if_command_node.go
+++ b/internal/pkg/text/template/parse/if_command_node.go
@@ -1,0 +1,123 @@
+package parse
+
+import (
+	"github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/helm"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+// IfCommandNode holds a command (a pipeline inside an "if" statement).  Since
+type IfCommandNode struct {
+	NodeType
+	Pos
+	tr   *Tree
+	Args []Node // Arguments in lexical order: Identifier, field, or constant.
+}
+
+func (t *Tree) newIfCommand(pos Pos) *IfCommandNode {
+	return &IfCommandNode{tr: t, NodeType: NodeIfCommand, Pos: pos}
+}
+
+func (c *IfCommandNode) append(arg Node) {
+	c.Args = append(c.Args, arg)
+}
+
+func (c *IfCommandNode) String() string {
+	var sb strings.Builder
+	c.writeTo(&sb)
+	return sb.String()
+}
+
+func (c *IfCommandNode) writeTo(sb *strings.Builder) {
+	// Handles problem #2 of if-conditional conversion;  the "boolean composition problem".
+	if commandNodeInversionIsRequired(&c.Args) {
+		positionInFile := c.Position()
+
+		logrus.Infof("Found an Argument sequence at position %d that requires Jinja2 syntax normalization: %s",
+			positionInFile, c.Args)
+		invertCommandNodes(&c.Args)
+		logrus.Infof("Conversion at position %d became %s", positionInFile, c.Args)
+	}
+
+	for i, arg := range c.Args {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if arg, ok := arg.(*IfPipeNode); ok {
+			sb.WriteByte('(')
+			arg.writeTo(sb)
+			sb.WriteByte(')')
+			continue
+		}
+		if isValueNode(arg.String()) {
+			writeValueNode(&arg, sb)
+		} else {
+			arg.writeTo(sb)
+		}
+	}
+}
+
+func (c *IfCommandNode) tree() *Tree {
+	return c.tr
+}
+
+func (c *IfCommandNode) Copy() Node {
+	if c == nil {
+		return c
+	}
+	n := c.tr.newIfCommand(c.Pos)
+	for _, c := range c.Args {
+		n.append(c.Copy())
+	}
+	return n
+}
+
+// Determine whether we need to invert nodes of the subtree to output in a Jinja2 compliant way.
+func commandNodeInversionIsRequired(args *[]Node) bool {
+	// CommandNode abstractions are used as the conditional clause in "if" statements.  In order to process an Args
+	// array for "if" containing "and", "or", or "eq" we must invert the first and second elements of the Args array.
+	// In other words, ["and", "condition1", "condition2"] will become ["condition1", "and", "condition2"].  This
+	// functionality determines whether inversion is necessary.
+	argsArray := *args
+	return len(argsArray) > 2 &&
+		(argsArray[0].String() == "and" || argsArray[0].String() == "or" || argsArray[0].String() == "eq")
+}
+
+// Side-effects the input array in order to swap elements at indexes 0 and 1.  This method does not check array length
+// and expects well formed input.
+func invertCommandNodes(args *[]Node) {
+	argsArray := *args
+	temp := argsArray[0]
+	argsArray[0] = argsArray[1]
+	argsArray[1] = temp
+}
+
+func isValueNode(nodeString string) bool {
+	return strings.HasPrefix(nodeString, ".Values.")
+}
+
+func removeValuesPrefix(fieldString string) string {
+	return strings.ReplaceAll(fieldString, ".Values.", "")
+}
+
+func writeValueNode(fieldNodeRef *Node, sb *strings.Builder) {
+	fieldNode := *fieldNodeRef
+	fieldNodePosition := fieldNode.Position()
+	fieldNodeString := fieldNode.String()
+	logrus.Infof("Found a candidate for conversion: %s", fieldNodeString)
+	unqualifiedName := removeValuesPrefix(fieldNodeString)
+	fieldIsLikelyBoolean, err := helm.ArgIsLikelyBooleanYamlValue(unqualifiedName)
+	if err != nil {
+		logrus.Warnf("\"%s\" at position %d was not found in Helm chart's values: %s.  Defaulting to definition conversion",
+			fieldNodeString, fieldNodePosition, err)
+	}
+	if fieldIsLikelyBoolean {
+		logrus.Infof("Determined %s at position %d is likely a boolean", fieldNodeString, fieldNodePosition)
+		sb.WriteString(unqualifiedName)
+	} else {
+		logrus.Infof("Determined %s at position %d is likely checking for definition, not boolean evaluation",
+			fieldNodeString, fieldNodePosition)
+		sb.WriteString(unqualifiedName)
+		sb.WriteString(" is defined")
+	}
+}

--- a/internal/pkg/text/template/parse/if_node.go
+++ b/internal/pkg/text/template/parse/if_node.go
@@ -1,0 +1,85 @@
+package parse
+
+import "strings"
+
+// IfNode is the representation of a "if" statement.  This is a tailored version of text/template's BranchNode.
+// The text/template package "if", "for" and "with" utilizing the BranchNode abstraction.  This makes sense, since the
+// types are all very similar in Go Templating, and they are all output in very similar manners.  However, Jinja2 has
+// greater requirements surrounding output of these Branch structures.  This abstraction is introduced to handle the
+// "if" BranchNode.
+//
+// Currently, the implementation makes a best guess to fully translate "if" conditionals.  There is not always a
+// deterministic conversion, which is discussed in much greater detail below.  However, this implementation makes a best
+// attempt approach to resolve a proper translation.  There are two major difference between Go Template conditionals
+// and Jinja2 conditionals:
+//
+// 1. If-Ambiguity:  In Go template language, a conditional such as "{{ if something }}" is overloaded and may mean:
+//
+//    "if something is true" (boolean evaluation) or "if something is defined" (definition check)
+//
+//    Jinja2 does not support this overloaded conditional evaluation behavior.  There is no deterministic way to tell
+//    whether an arbitrary condition is expressing boolean evaluation or checking for definition without further
+//    information.  Thus, a heuristic is introduced to make a best guess.  The input Helm Chart's Values.yaml file is
+//    interrogated for the "something" key.  If "something" exists and its value is a boolean, then the conditional is
+//    classified as boolean evaluation, and will output as:
+//
+//    {% if something %}
+//
+//    Otherwise, if the key is not found or the value is not a boolean, then the conditional is classified as a
+//    definition check.  In this case, the Jinja2 output is:
+//
+//    {% if something is defined %}
+//
+//    Note:  You must uncomment optional configuration in order for this heuristic to work accurately.
+//
+// 2. Boolean-Composition: Go Template language treats boolean operators ("and", "or", "not") as function calls.  Thus,
+//    the syntax is "<booleanOperator> <condition1> <condition2>".  Treating such operators as function invocations is
+//    a common tactic in language development, as it significantly reduces the complexity of the parser.  However,
+//    Jinja2 treats boolean operators in a more traditional way, and expects the syntax
+//    "<condition1> <booleanOperator> <condition2>".  Additionally, Go template language implements an "eq" equality
+//    operator, which works in a similar way to the Go template boolean operator implementation.  In these cases, the
+//    Abstract Syntax Tree nodes must be re-ordered in order to output proper Jinja2.  The "swapping" of nodes in memory
+//    is necessary since these statements can, and often are, heavily nested.
+type IfNode struct {
+	NodeType
+	Pos
+	tr       *Tree
+	Line     int          // The line number in the input. Deprecated: Kept for compatibility.
+	Pipe     *IfPipeNode // The pipeline to be evaluated.
+	List     *ListNode   // What to execute if the value is non-empty.
+	ElseList *ListNode   // What to execute if the value is empty (nil if absent).
+}
+
+func (n *IfNode) String() string {
+	var sb strings.Builder
+	n.writeTo(&sb)
+	return sb.String()
+}
+
+func (n *IfNode) writeTo(sb *strings.Builder) {
+    // This implementation has been greatly simplified from the original BranchNode.writeTo(*strings.Builder) impl:
+	// https://github.com/golang/go/blob/master/src/text/template/parse/node.go#L822
+	// This is largely due to the fact that the "IfNode" type is abstracted to handle "if" statements specifically.
+	// Removal of the overloaded functionality allows greater specificity in outputting the Node.
+	sb.WriteString("{% if ")
+	n.Pipe.writeTo(sb)
+	sb.WriteString(" %}")
+	n.List.writeTo(sb)
+	if n.ElseList != nil {
+		sb.WriteString("{% else %}")
+		n.ElseList.writeTo(sb)
+	}
+	sb.WriteString("{% endif %}")
+}
+
+func (t *Tree) newIf(pos Pos, line int, pipe *IfPipeNode, list, elseList *ListNode) *IfNode {
+	return &IfNode{tr: t, NodeType: NodeIf, Pos: pos, Line: line, Pipe: pipe, List: list, ElseList: elseList}
+}
+
+func (n *IfNode) Copy() Node {
+	return n.tr.newIf(n.Pos, n.Line, n.Pipe.CopyPipe(), n.List.CopyList(), n.ElseList.CopyList())
+}
+
+func (n *IfNode) tree() *Tree {
+	return n.tr
+}

--- a/internal/pkg/text/template/parse/if_pipe_node.go
+++ b/internal/pkg/text/template/parse/if_pipe_node.go
@@ -1,0 +1,66 @@
+package parse
+
+import "strings"
+
+// IfPipeNode holds an "if" pipeline (i.e., everything after "{{ if ").  IfPipeNode was abstracted from the generic
+// PipeNode in order to hand tailor Jinja2 output, which varies greatly from other branch structures in the Jinja2
+// template language.
+type IfPipeNode struct {
+	NodeType
+	Pos
+	tr       *Tree
+	Line     int
+	IsAssign bool
+	Decl     []*VariableNode  // Kept for backwards compatibility.  Since PipeNode was once overloaded to mean several
+	                          // things, declarations were optional (i.e., "range").
+	Cmds     []*IfCommandNode // Commands for "if" statements are now of type IfCommandNode, which has greater
+	                          // adequate functionality to output in a Jinja2 compliant manner.  (i.e., it will solve
+	                          // the if-ambiguity and boolean-composition problems.
+}
+
+func (p *IfPipeNode) append(command *IfCommandNode) {
+	p.Cmds = append(p.Cmds, command)
+}
+
+func (p *IfPipeNode) String() string {
+	var sb strings.Builder
+	p.writeTo(&sb)
+	return sb.String()
+}
+
+func (t *Tree) newIfPipeline(pos Pos, line int, vars []*VariableNode) *IfPipeNode {
+	return &IfPipeNode{tr: t, NodeType: NodePipeIf, Pos: pos, Line: line, Decl: vars}
+}
+
+func (p *IfPipeNode) writeTo(sb *strings.Builder) {
+	for i, c := range p.Cmds {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		c.writeTo(sb)
+	}
+}
+
+func (p *IfPipeNode) tree() *Tree {
+	return p.tr
+}
+
+func (p *IfPipeNode) CopyPipe() *IfPipeNode {
+	if p == nil {
+		return p
+	}
+	vars := make([]*VariableNode, len(p.Decl))
+	for i, d := range p.Decl {
+		vars[i] = d.Copy().(*VariableNode)
+	}
+	n := p.tr.newIfPipeline(p.Pos, p.Line, vars)
+	n.IsAssign = p.IsAssign
+	for _, c := range p.Cmds {
+		n.append(c.Copy().(*IfCommandNode))
+	}
+	return n
+}
+
+func (p *IfPipeNode) Copy() Node {
+	return p.CopyPipe()
+}

--- a/internal/pkg/text/template/parse/node_test.go
+++ b/internal/pkg/text/template/parse/node_test.go
@@ -1,9 +1,8 @@
 package parse_test
 
 import (
-	"github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/convert"
 	"github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/helm"
-	j2template "github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/text/template"
+	template2 "github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/text/template"
 	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"testing"
 )
+
+const helmTemplatesDirectory = "templates"
 
 // Represents the meta-information for a contrived chart test case.
 type testCase struct {
@@ -39,6 +40,10 @@ var testCases = []testCase{
 		"basic_sprig",
 		"testdata/basic_sprig",
 	},
+	{
+		"basic_with",
+		"testdata/basic_with",
+	},
 }
 
 // Reads the files in a directory, exiting fatally if any errors occur.
@@ -54,7 +59,8 @@ func readDir(directory string, t *testing.T) ([]os.FileInfo, error) {
 
 func TestToString(t *testing.T) {
 	for _, testCase := range testCases {
-		templatesDirectory := path.Join(testCase.chartDir, convert.HelmTemplatesDirectory)
+		logrus.Infof("Running: %s", testCase.name)
+		templatesDirectory := path.Join(testCase.chartDir, helmTemplatesDirectory)
 		templateFiles, err := readDir(templatesDirectory, t)
 		if err != nil {
 			t.Errorf("Couldn't read: %s", templatesDirectory)
@@ -64,9 +70,9 @@ func TestToString(t *testing.T) {
 			cwd, _ := os.Getwd()
 			helm.HelmChartRef = path.Join(cwd, testCase.chartDir)
 			templateFilePath := path.Join(templatesDirectory, testFileName)
-			template, err := j2template.New(testFileName).
+			template, err := template2.New(testFileName).
 				Option("missingkey=zero").
-				Funcs(convert.HelmFuncMap()).
+				Funcs(template2.HelmFuncMap()).
 				ParseFiles(templateFilePath)
 			if err != nil {
 				t.Errorf("Unexpected error while parsing %s: %s", testFileName, err)

--- a/internal/pkg/text/template/parse/parse_test.go
+++ b/internal/pkg/text/template/parse/parse_test.go
@@ -1,0 +1,608 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package parse
+
+import (
+	"flag"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"strings"
+	"testing"
+)
+
+var debug = flag.Bool("debug", false, "show the errors produced by the main tests")
+
+type numberTest struct {
+	text      string
+	isInt     bool
+	isUint    bool
+	isFloat   bool
+	isComplex bool
+	int64
+	uint64
+	float64
+	complex128
+}
+
+var numberTests = []numberTest{
+	// basics
+	{"0", true, true, true, false, 0, 0, 0, 0},
+	{"-0", true, true, true, false, 0, 0, 0, 0}, // check that -0 is a uint.
+	{"73", true, true, true, false, 73, 73, 73, 0},
+	{"7_3", true, true, true, false, 73, 73, 73, 0},
+	{"0b10_010_01", true, true, true, false, 73, 73, 73, 0},
+	{"0B10_010_01", true, true, true, false, 73, 73, 73, 0},
+	{"073", true, true, true, false, 073, 073, 073, 0},
+	{"0o73", true, true, true, false, 073, 073, 073, 0},
+	{"0O73", true, true, true, false, 073, 073, 073, 0},
+	{"0x73", true, true, true, false, 0x73, 0x73, 0x73, 0},
+	{"0X73", true, true, true, false, 0x73, 0x73, 0x73, 0},
+	{"0x7_3", true, true, true, false, 0x73, 0x73, 0x73, 0},
+	{"-73", true, false, true, false, -73, 0, -73, 0},
+	{"+73", true, false, true, false, 73, 0, 73, 0},
+	{"100", true, true, true, false, 100, 100, 100, 0},
+	{"1e9", true, true, true, false, 1e9, 1e9, 1e9, 0},
+	{"-1e9", true, false, true, false, -1e9, 0, -1e9, 0},
+	{"-1.2", false, false, true, false, 0, 0, -1.2, 0},
+	{"1e19", false, true, true, false, 0, 1e19, 1e19, 0},
+	{"1e1_9", false, true, true, false, 0, 1e19, 1e19, 0},
+	{"1E19", false, true, true, false, 0, 1e19, 1e19, 0},
+	{"-1e19", false, false, true, false, 0, 0, -1e19, 0},
+	{"0x_1p4", true, true, true, false, 16, 16, 16, 0},
+	{"0X_1P4", true, true, true, false, 16, 16, 16, 0},
+	{"0x_1p-4", false, false, true, false, 0, 0, 1 / 16., 0},
+	{"4i", false, false, false, true, 0, 0, 0, 4i},
+	{"-1.2+4.2i", false, false, false, true, 0, 0, 0, -1.2 + 4.2i},
+	{"073i", false, false, false, true, 0, 0, 0, 73i}, // not octal!
+	// complex with 0 imaginary are float (and maybe integer)
+	{"0i", true, true, true, true, 0, 0, 0, 0},
+	{"-1.2+0i", false, false, true, true, 0, 0, -1.2, -1.2},
+	{"-12+0i", true, false, true, true, -12, 0, -12, -12},
+	{"13+0i", true, true, true, true, 13, 13, 13, 13},
+	// funny bases
+	{"0123", true, true, true, false, 0123, 0123, 0123, 0},
+	{"-0x0", true, true, true, false, 0, 0, 0, 0},
+	{"0xdeadbeef", true, true, true, false, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0},
+	// character constants
+	{`'a'`, true, true, true, false, 'a', 'a', 'a', 0},
+	{`'\n'`, true, true, true, false, '\n', '\n', '\n', 0},
+	{`'\\'`, true, true, true, false, '\\', '\\', '\\', 0},
+	{`'\''`, true, true, true, false, '\'', '\'', '\'', 0},
+	{`'\xFF'`, true, true, true, false, 0xFF, 0xFF, 0xFF, 0},
+	{`'パ'`, true, true, true, false, 0x30d1, 0x30d1, 0x30d1, 0},
+	{`'\u30d1'`, true, true, true, false, 0x30d1, 0x30d1, 0x30d1, 0},
+	{`'\U000030d1'`, true, true, true, false, 0x30d1, 0x30d1, 0x30d1, 0},
+	// some broken syntax
+	{text: "+-2"},
+	{text: "0x123."},
+	{text: "1e."},
+	{text: "0xi."},
+	{text: "1+2."},
+	{text: "'x"},
+	{text: "'xx'"},
+	{text: "'433937734937734969526500969526500'"}, // Integer too large - issue 10634.
+	// Issue 8622 - 0xe parsed as floating point. Very embarrassing.
+	{"0xef", true, true, true, false, 0xef, 0xef, 0xef, 0},
+}
+
+func TestNumberParse(t *testing.T) {
+	for _, test := range numberTests {
+		// If fmt.Sscan thinks it's complex, it's complex. We can't trust the output
+		// because imaginary comes out as a number.
+		var c complex128
+		typ := itemNumber
+		var tree *Tree
+		if test.text[0] == '\'' {
+			typ = itemCharConstant
+		} else {
+			_, err := fmt.Sscan(test.text, &c)
+			if err == nil {
+				typ = itemComplex
+			}
+		}
+		n, err := tree.newNumber(0, test.text, typ)
+		ok := test.isInt || test.isUint || test.isFloat || test.isComplex
+		if ok && err != nil {
+			t.Errorf("unexpected error for %q: %s", test.text, err)
+			continue
+		}
+		if !ok && err == nil {
+			t.Errorf("expected error for %q", test.text)
+			continue
+		}
+		if !ok {
+			if *debug {
+				fmt.Printf("%s\n\t%s\n", test.text, err)
+			}
+			continue
+		}
+		if n.IsComplex != test.isComplex {
+			t.Errorf("complex incorrect for %q; should be %t", test.text, test.isComplex)
+		}
+		if test.isInt {
+			if !n.IsInt {
+				t.Errorf("expected integer for %q", test.text)
+			}
+			if n.Int64 != test.int64 {
+				t.Errorf("int64 for %q should be %d Is %d", test.text, test.int64, n.Int64)
+			}
+		} else if n.IsInt {
+			t.Errorf("did not expect integer for %q", test.text)
+		}
+		if test.isUint {
+			if !n.IsUint {
+				t.Errorf("expected unsigned integer for %q", test.text)
+			}
+			if n.Uint64 != test.uint64 {
+				t.Errorf("uint64 for %q should be %d Is %d", test.text, test.uint64, n.Uint64)
+			}
+		} else if n.IsUint {
+			t.Errorf("did not expect unsigned integer for %q", test.text)
+		}
+		if test.isFloat {
+			if !n.IsFloat {
+				t.Errorf("expected float for %q", test.text)
+			}
+			if n.Float64 != test.float64 {
+				t.Errorf("float64 for %q should be %g Is %g", test.text, test.float64, n.Float64)
+			}
+		} else if n.IsFloat {
+			t.Errorf("did not expect float for %q", test.text)
+		}
+		if test.isComplex {
+			if !n.IsComplex {
+				t.Errorf("expected complex for %q", test.text)
+			}
+			if n.Complex128 != test.complex128 {
+				t.Errorf("complex128 for %q should be %g Is %g", test.text, test.complex128, n.Complex128)
+			}
+		} else if n.IsComplex {
+			t.Errorf("did not expect complex for %q", test.text)
+		}
+	}
+}
+
+type parseTest struct {
+	name   string
+	input  string
+	ok     bool
+	result string // what the user would see in an error message.
+}
+
+const (
+	//noError  = true
+	hasError = false
+)
+
+//var parseTests = []parseTest{
+//	{"empty", "", noError,
+//		``},
+//	{"comment", "{{/*\n\n\n*/}}", noError,
+//		``},
+//	{"spaces", " \t\n", noError,
+//		`" \t\n"`},
+//	{"text", "some text", noError,
+//		`"some text"`},
+//	{"emptyAction", "{{}}", hasError,
+//		`{{}}`},
+//	{"field", "{{.X}}", noError,
+//		`{{.X}}`},
+//	{"simple command", "{{printf}}", noError,
+//		`{{printf}}`},
+//	{"$ invocation", "{{$}}", noError,
+//		"{{$}}"},
+//	{"variable invocation", "{{with $x := 3}}{{$x 23}}{{end}}", noError,
+//		"{{with $x := 3}}{{$x 23}}{{end}}"},
+//	{"variable with fields", "{{$.I}}", noError,
+//		"{{$.I}}"},
+//	{"multi-word command", "{{printf `%d` 23}}", noError,
+//		"{{printf `%d` 23}}"},
+//	{"pipeline", "{{.X|.Y}}", noError,
+//		`{{.X | .Y}}`},
+//	{"pipeline with decl", "{{$x := .X|.Y}}", noError,
+//		`{{$x := .X | .Y}}`},
+//	{"nested pipeline", "{{.X (.Y .Z) (.A | .B .C) (.E)}}", noError,
+//		`{{.X (.Y .Z) (.A | .B .C) (.E)}}`},
+//	{"field applied to parentheses", "{{(.Y .Z).Field}}", noError,
+//		`{{(.Y .Z).Field}}`},
+//	{"simple if", "{{if .X}}hello{{end}}", noError,
+//		`{{if .X}}"hello"{{end}}`},
+//	{"if with else", "{{if .X}}true{{else}}false{{end}}", noError,
+//		`{{if .X}}"true"{{else}}"false"{{end}}`},
+//	{"if with else if", "{{if .X}}true{{else if .Y}}false{{end}}", noError,
+//		`{{if .X}}"true"{{else}}{{if .Y}}"false"{{end}}{{end}}`},
+//	{"if else chain", "+{{if .X}}X{{else if .Y}}Y{{else if .Z}}Z{{end}}+", noError,
+//		`"+"{{if .X}}"X"{{else}}{{if .Y}}"Y"{{else}}{{if .Z}}"Z"{{end}}{{end}}{{end}}"+"`},
+//	{"simple range", "{{range .X}}hello{{end}}", noError,
+//		`{{range .X}}"hello"{{end}}`},
+//	{"chained field range", "{{range .X.Y.Z}}hello{{end}}", noError,
+//		`{{range .X.Y.Z}}"hello"{{end}}`},
+//	{"nested range", "{{range .X}}hello{{range .Y}}goodbye{{end}}{{end}}", noError,
+//		`{{range .X}}"hello"{{range .Y}}"goodbye"{{end}}{{end}}`},
+//	{"range with else", "{{range .X}}true{{else}}false{{end}}", noError,
+//		`{{range .X}}"true"{{else}}"false"{{end}}`},
+//	{"range over pipeline", "{{range .X|.M}}true{{else}}false{{end}}", noError,
+//		`{{range .X | .M}}"true"{{else}}"false"{{end}}`},
+//	{"range []int", "{{range .SI}}{{.}}{{end}}", noError,
+//		`{{range .SI}}{{.}}{{end}}`},
+//	{"range 1 var", "{{range $x := .SI}}{{.}}{{end}}", noError,
+//		`{{range $x := .SI}}{{.}}{{end}}`},
+//	{"range 2 vars", "{{range $x, $y := .SI}}{{.}}{{end}}", noError,
+//		`{{range $x, $y := .SI}}{{.}}{{end}}`},
+//	{"constants", "{{range .SI 1 -3.2i true false 'a' nil}}{{end}}", noError,
+//		`{{range .SI 1 -3.2i true false 'a' nil}}{{end}}`},
+//	{"template", "{{template `x`}}", noError,
+//		`{{template "x"}}`},
+//	{"template with arg", "{{template `x` .Y}}", noError,
+//		`{{template "x" .Y}}`},
+//	{"with", "{{with .X}}hello{{end}}", noError,
+//		`{{with .X}}"hello"{{end}}`},
+//	{"with with else", "{{with .X}}hello{{else}}goodbye{{end}}", noError,
+//		`{{with .X}}"hello"{{else}}"goodbye"{{end}}`},
+//	// Trimming spaces.
+//	{"trim left", "x \r\n\t{{- 3}}", noError, `"x"{{3}}`},
+//	{"trim right", "{{3 -}}\n\n\ty", noError, `{{3}}"y"`},
+//	{"trim left and right", "x \r\n\t{{- 3 -}}\n\n\ty", noError, `"x"{{3}}"y"`},
+//	{"trim with extra spaces", "x\n{{-  3   -}}\ny", noError, `"x"{{3}}"y"`},
+//	{"comment trim left", "x \r\n\t{{- /* hi */}}", noError, `"x"`},
+//	{"comment trim right", "{{/* hi */ -}}\n\n\ty", noError, `"y"`},
+//	{"comment trim left and right", "x \r\n\t{{- /* */ -}}\n\n\ty", noError, `"x""y"`},
+//	{"block definition", `{{block "foo" .}}hello{{end}}`, noError,
+//		`{{template "foo" .}}`},
+//	// Errors.
+//	{"unclosed action", "hello{{range", hasError, ""},
+//	{"unmatched end", "{{end}}", hasError, ""},
+//	{"unmatched else", "{{else}}", hasError, ""},
+//	{"unmatched else after if", "{{if .X}}hello{{end}}{{else}}", hasError, ""},
+//	{"multiple else", "{{if .X}}1{{else}}2{{else}}3{{end}}", hasError, ""},
+//	{"missing end", "hello{{range .x}}", hasError, ""},
+//	{"missing end after else", "hello{{range .x}}{{else}}", hasError, ""},
+//	{"undefined function", "hello{{undefined}}", hasError, ""},
+//	{"undefined variable", "{{$x}}", hasError, ""},
+//	{"variable undefined after end", "{{with $x := 4}}{{end}}{{$x}}", hasError, ""},
+//	{"variable undefined in template", "{{template $v}}", hasError, ""},
+//	{"declare with field", "{{with $x.Y := 4}}{{end}}", hasError, ""},
+//	{"template with field ref", "{{template .X}}", hasError, ""},
+//	{"template with var", "{{template $v}}", hasError, ""},
+//	{"invalid punctuation", "{{printf 3, 4}}", hasError, ""},
+//	{"multidecl outside range", "{{with $v, $u := 3}}{{end}}", hasError, ""},
+//	{"too many decls in range", "{{range $u, $v, $w := 3}}{{end}}", hasError, ""},
+//	{"dot applied to parentheses", "{{printf (printf .).}}", hasError, ""},
+//	{"adjacent args", "{{printf 3`x`}}", hasError, ""},
+//	{"adjacent args with .", "{{printf `x`.}}", hasError, ""},
+//	{"extra end after if", "{{if .X}}a{{else if .Y}}b{{end}}{{end}}", hasError, ""},
+//	// Other kinds of assignments and operators aren't available yet.
+//	{"bug0a", "{{$x := 0}}{{$x}}", noError, "{{$x := 0}}{{$x}}"},
+//	{"bug0b", "{{$x += 1}}{{$x}}", hasError, ""},
+//	{"bug0c", "{{$x ! 2}}{{$x}}", hasError, ""},
+//	{"bug0d", "{{$x % 3}}{{$x}}", hasError, ""},
+//	// Check the parse fails for := rather than comma.
+//	{"bug0e", "{{range $x := $y := 3}}{{end}}", hasError, ""},
+//	// Another bug: variable read must ignore following punctuation.
+//	{"bug1a", "{{$x:=.}}{{$x!2}}", hasError, ""},                     // ! is just illegal here.
+//	{"bug1b", "{{$x:=.}}{{$x+2}}", hasError, ""},                     // $x+2 should not parse as ($x) (+2).
+//	{"bug1c", "{{$x:=.}}{{$x +2}}", noError, "{{$x := .}}{{$x +2}}"}, // It's OK with a space.
+//	// dot following a literal value
+//	{"dot after integer", "{{1.E}}", hasError, ""},
+//	{"dot after float", "{{0.1.E}}", hasError, ""},
+//	{"dot after boolean", "{{true.E}}", hasError, ""},
+//	{"dot after char", "{{'a'.any}}", hasError, ""},
+//	{"dot after string", `{{"hello".guys}}`, hasError, ""},
+//	{"dot after dot", "{{..E}}", hasError, ""},
+//	{"dot after nil", "{{nil.E}}", hasError, ""},
+//	// Wrong pipeline
+//	{"wrong pipeline dot", "{{12|.}}", hasError, ""},
+//	{"wrong pipeline number", "{{.|12|printf}}", hasError, ""},
+//	{"wrong pipeline string", "{{.|printf|\"error\"}}", hasError, ""},
+//	{"wrong pipeline char", "{{12|printf|'e'}}", hasError, ""},
+//	{"wrong pipeline boolean", "{{.|true}}", hasError, ""},
+//	{"wrong pipeline nil", "{{'c'|nil}}", hasError, ""},
+//	{"empty pipeline", `{{printf "%d" ( ) }}`, hasError, ""},
+//	// Missing pipeline in block
+//	{"block definition", `{{block "foo"}}hello{{end}}`, hasError, ""},
+//}
+
+var builtins = map[string]interface{}{
+	"printf":   fmt.Sprintf,
+	"contains": strings.Contains,
+}
+
+//func testParse(doCopy bool, t *testing.T) {
+//	textFormat = "%q"
+//	defer func() { textFormat = "%s" }()
+//	for _, test := range parseTests {
+//		tmpl, err := New(test.name).Parse(test.input, "", "", make(map[string]*Tree), builtins)
+//		switch {
+//		case err == nil && !test.ok:
+//			t.Errorf("%q: expected error; got none", test.name)
+//			continue
+//		case err != nil && test.ok:
+//			t.Errorf("%q: unexpected error: %v", test.name, err)
+//			continue
+//		case err != nil && !test.ok:
+//			// expected error, got one
+//			if *debug {
+//				fmt.Printf("%s: %s\n\t%s\n", test.name, test.input, err)
+//			}
+//			continue
+//		}
+//		var result string
+//		if doCopy {
+//			result = tmpl.Root.Copy().String()
+//		} else {
+//			result = tmpl.Root.String()
+//		}
+//		if result != test.result {
+//			t.Errorf("%s=(%q): got\n\t%v\nexpected\n\t%v", test.name, test.input, result, test.result)
+//		}
+//	}
+//}
+
+//func TestParse(t *testing.T) {
+//	testParse(false, t)
+//}
+
+// Same as TestParse, but we copy the node first
+//func TestParseCopy(t *testing.T) {
+//	testParse(true, t)
+//}
+
+type isEmptyTest struct {
+	name  string
+	input string
+	empty bool
+}
+
+var isEmptyTests = []isEmptyTest{
+	{"empty", ``, true},
+	{"nonempty", `hello`, false},
+	{"spaces only", " \t\n \t\n", true},
+	{"definition", `{{define "x"}}something{{end}}`, true},
+	{"definitions and space", "{{define `x`}}something{{end}}\n\n{{define `y`}}something{{end}}\n\n", true},
+	{"definitions and text", "{{define `x`}}something{{end}}\nx\n{{define `y`}}something{{end}}\ny\n", false},
+	{"definition and action", "{{define `x`}}something{{end}}{{if 3}}foo{{end}}", false},
+}
+
+func TestIsEmpty(t *testing.T) {
+	if !IsEmptyTree(nil) {
+		t.Errorf("nil tree is not empty")
+	}
+	for _, test := range isEmptyTests {
+		tree, err := New("root").Parse(test.input, "", "", make(map[string]*Tree), nil)
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", test.name, err)
+			continue
+		}
+		if empty := IsEmptyTree(tree.Root); empty != test.empty {
+			t.Errorf("%q: expected %t got %t", test.name, test.empty, empty)
+		}
+	}
+}
+
+func TestErrorContextWithTreeCopy(t *testing.T) {
+	tree, err := New("root").Parse("{{if true}}{{end}}", "", "", make(map[string]*Tree), nil)
+	if err != nil {
+		t.Fatalf("unexpected tree parse failure: %v", err)
+	}
+	treeCopy := tree.Copy()
+	wantLocation, wantContext := tree.ErrorContext(tree.Root.Nodes[0])
+	gotLocation, gotContext := treeCopy.ErrorContext(treeCopy.Root.Nodes[0])
+	if wantLocation != gotLocation {
+		t.Errorf("wrong error location want %q got %q", wantLocation, gotLocation)
+	}
+	if wantContext != gotContext {
+		t.Errorf("wrong error location want %q got %q", wantContext, gotContext)
+	}
+}
+
+// All failures, and the result is a string that must appear in the error message.
+var errorTests = []parseTest{
+	// Check line numbers are accurate.
+	{"unclosed1",
+		"line1\n{{",
+		hasError, `unclosed1:2: unexpected unclosed action in command`},
+	{"unclosed2",
+		"line1\n{{define `x`}}line2\n{{",
+		hasError, `unclosed2:3: unexpected unclosed action in command`},
+	// Specific errors.
+	{"function",
+		"{{foo}}",
+		hasError, `function "foo" not defined`},
+	{"comment",
+		"{{/*}}",
+		hasError, `unclosed comment`},
+	{"lparen",
+		"{{.X (1 2 3}}",
+		hasError, `unclosed left paren`},
+	{"rparen",
+		"{{.X 1 2 3)}}",
+		hasError, `unexpected ")"`},
+	{"space",
+		"{{`x`3}}",
+		hasError, `in operand`},
+	{"idchar",
+		"{{a#}}",
+		hasError, `'#'`},
+	{"charconst",
+		"{{'a}}",
+		hasError, `unterminated character constant`},
+	{"stringconst",
+		`{{"a}}`,
+		hasError, `unterminated quoted string`},
+	{"rawstringconst",
+		"{{`a}}",
+		hasError, `unterminated raw quoted string`},
+	{"number",
+		"{{0xi}}",
+		hasError, `number syntax`},
+	{"multidefine",
+		"{{define `a`}}a{{end}}{{define `a`}}b{{end}}",
+		hasError, `multiple definition of template`},
+	{"eof",
+		"{{range .X}}",
+		hasError, `unexpected EOF`},
+	{"variable",
+		// Declare $x so it's defined, to avoid that error, and then check we don't parse a declaration.
+		"{{$x := 23}}{{with $x.y := 3}}{{$x 23}}{{end}}",
+		hasError, `unexpected ":="`},
+	{"multidecl",
+		"{{$a,$b,$c := 23}}",
+		hasError, `too many declarations`},
+	{"undefvar",
+		"{{$a}}",
+		hasError, `undefined variable`},
+	{"wrongdot",
+		"{{true.any}}",
+		hasError, `unexpected . after term`},
+	{"wrongpipeline",
+		"{{12|false}}",
+		hasError, `non executable command in pipeline`},
+	{"emptypipeline",
+		`{{ ( ) }}`,
+		hasError, `missing value for parenthesized pipeline`},
+	{"multilinerawstring",
+		"{{ $v := `\n` }} {{",
+		hasError, `multilinerawstring:2: unexpected unclosed action`},
+	{"rangeundefvar",
+		"{{range $k}}{{end}}",
+		hasError, `undefined variable`},
+	{"rangeundefvars",
+		"{{range $k, $v}}{{end}}",
+		hasError, `undefined variable`},
+	{"rangemissingvalue1",
+		"{{range $k,}}{{end}}",
+		hasError, `missing value for range`},
+	{"rangemissingvalue2",
+		"{{range $k, $v := }}{{end}}",
+		hasError, `missing value for range`},
+	{"rangenotvariable1",
+		"{{range $k, .}}{{end}}",
+		hasError, `range can only initialize variables`},
+	{"rangenotvariable2",
+		"{{range $k, 123 := .}}{{end}}",
+		hasError, `range can only initialize variables`},
+}
+
+func TestErrors(t *testing.T) {
+	for _, test := range errorTests {
+		ok := test.ok
+		logrus.Debug(ok)
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(test.name).Parse(test.input, "", "", make(map[string]*Tree))
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", test.result)
+			}
+			if !strings.Contains(err.Error(), test.result) {
+				t.Fatalf("error %q does not contain %q", err, test.result)
+			}
+		})
+	}
+}
+
+//func TestBlock(t *testing.T) {
+//	const (
+//		input = `a{{block "inner" .}}bar{{.}}baz{{end}}b`
+//		outer = `a{{template "inner" .}}b`
+//		inner = `bar{{.}}baz`
+//	)
+//	treeSet := make(map[string]*Tree)
+//	tmpl, err := New("outer").Parse(input, "", "", treeSet, nil)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	if g, w := tmpl.Root.String(), outer; g != w {
+//		t.Errorf("outer template = %q, want %q", g, w)
+//	}
+//	inTmpl := treeSet["inner"]
+//	if inTmpl == nil {
+//		t.Fatal("block did not define template")
+//	}
+//	if g, w := inTmpl.Root.String(), inner; g != w {
+//		t.Errorf("inner template = %q, want %q", g, w)
+//	}
+//}
+
+func TestLineNum(t *testing.T) {
+	const count = 100
+	text := strings.Repeat("{{printf 1234}}\n", count)
+	tree, err := New("bench").Parse(text, "", "", make(map[string]*Tree), builtins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check the line numbers. Each line is an action containing a template, followed by text.
+	// That's two nodes per line.
+	nodes := tree.Root.Nodes
+	for i := 0; i < len(nodes); i += 2 {
+		line := 1 + i/2
+		// Action first.
+		action := nodes[i].(*ActionNode)
+		if action.Line != line {
+			t.Fatalf("line %d: action is line %d", line, action.Line)
+		}
+		pipe := action.Pipe
+		if pipe.Line != line {
+			t.Fatalf("line %d: pipe is line %d", line, pipe.Line)
+		}
+	}
+}
+
+func BenchmarkParseLarge(b *testing.B) {
+	text := strings.Repeat("{{1234}}\n", 10000)
+	for i := 0; i < b.N; i++ {
+		_, err := New("bench").Parse(text, "", "", make(map[string]*Tree), builtins)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+var sinkv, sinkl string
+
+func BenchmarkVariableString(b *testing.B) {
+	v := &VariableNode{
+		Ident: []string{"$", "A", "BB", "CCC", "THIS_IS_THE_VARIABLE_BEING_PROCESSED"},
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sinkv = v.String()
+	}
+	if sinkv == "" {
+		b.Fatal("Benchmark was not run")
+	}
+}
+
+func BenchmarkListString(b *testing.B) {
+	text := `
+{{(printf .Field1.Field2.Field3).Value}}
+{{$x := (printf .Field1.Field2.Field3).Value}}
+{{$y := (printf $x.Field1.Field2.Field3).Value}}
+{{$z := $y.Field1.Field2.Field3}}
+{{if contains $y $z}}
+	{{printf "%q" $y}}
+{{else}}
+	{{printf "%q" $x}}
+{{end}}
+{{with $z.Field1 | contains "boring"}}
+	{{printf "%q" . | printf "%s"}}
+{{else}}
+	{{printf "%d %d %d" 11 11 11}}
+	{{printf "%d %d %s" 22 22 $x.Field1.Field2.Field3 | printf "%s"}}
+	{{printf "%v" (contains $z.Field1.Field2 $y)}}
+{{end}}
+`
+	tree, err := New("bench").Parse(text, "", "", make(map[string]*Tree), builtins)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sinkl = tree.Root.String()
+	}
+	if sinkl == "" {
+		b.Fatal("Benchmark was not run")
+	}
+}

--- a/internal/pkg/text/template/parse/range_node.go
+++ b/internal/pkg/text/template/parse/range_node.go
@@ -1,0 +1,214 @@
+package parse
+
+import (
+	"github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/helm"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+// RangeNode is the representation of a "range" statement.  This is a tailored version of text/template's BranchNode.
+// The text/template package "if", "for" and "with" utilizing the BranchNode abstraction.  This makes sense, since the
+// types are all very similar in Go Templating, and they are all output in very similar manners.  However, Jinja2 has
+// greater requirements surrounding output of these Branch structures.  This abstraction is introduced to handle the
+// "range" BranchNode.
+//
+// Currently, the implementation outputs range statements using Ansible for-statement equivalents.  For example, given
+// the list-range input:
+//
+// {{ range list }}
+//
+// The translation is:
+//
+// {% for item_list in list %}
+//
+// Go Template language also supports range over maps.  For the given map-range input:
+//
+// {{ range $key, $value := someDict }}
+//
+// The translation is:
+//
+// {% for key, value in someDict.iterItems() %}
+//
+// Lastly, in the case of list-range input, Go Template language implies an iterator.  That is, you can access
+// properties of the list using the member access operator ".".  For example:
+//
+// {{ range computerList }}
+// {{ .ipAddress }}
+// {{ end }}
+//
+// The RangeNode implementation addresses this by appending the iterator variable name.  The translation is:
+//
+// {% for item_computerList in computerList %}
+// {{ item_computerList.ipAddress }}
+// {% endfor %}
+type RangeNode struct {
+	NodeType
+	Pos
+	tr       *Tree
+	Line     int            // The line number in the input. Deprecated: Kept for compatibility.
+	Pipe     *RangePipeNode // The pipeline to be evaluated.
+	List     *ListNode      // What to execute if the value is non-empty.
+	ElseList *ListNode      // What to execute if the value is empty (nil if absent).
+}
+
+func (t *Tree) newRange(pos Pos, line int, pipe *RangePipeNode, list, elseList *ListNode) *RangeNode {
+	return &RangeNode{tr: t, NodeType: NodeRange, Pos: pos, Line: line, Pipe: pipe, List: list, ElseList: elseList}
+}
+
+func (r *RangeNode) String() string {
+	var sb strings.Builder
+	r.writeTo(&sb)
+	return sb.String()
+}
+
+func (r *RangeNode) RemoveVarPrefix(prefix string) {
+	for _, v := range r.Pipe.Decl {
+		for i := range v.Ident {
+			v.Ident[i] = strings.TrimPrefix(v.Ident[i], prefix)
+		}
+	}
+}
+
+// GetRangeUseCaseType ... get difference cases for range flow
+func (r *RangeNode) GetRangeUseCaseType() RangeUseCaseType {
+	if len(r.Pipe.Decl) == 0 && len(r.Pipe.Cmds[0].Args) == 1 {
+		return UseCaseNoVariables
+	} else if len(r.Pipe.Decl) == 2 { //key value
+		return UseCaseKeyValue
+	} else if len(r.Pipe.Decl) == 1 && len(r.Pipe.Cmds[0].Args) == 1 { //$host and one value
+		return UseCaseSingleValue
+	} else if len(r.Pipe.Decl) == 0 && len(r.Pipe.Cmds[0].Args) == 1 && r.Pipe.Cmds[0].Args[0].String() == "tuple" {
+		return UseCaseTuple
+	}
+	return UseCaseDefault
+}
+
+// RangeUseCaseType identifies the types of uses cases for range.
+type RangeUseCaseType int
+
+/*-------------------------------------------------------------------------------------------------------
+  | INPUT                                  | LHS(vars) & RHS(cmds) |  OUTPUT                              |
+   --------------------------------------------------------------------------------------------------------
+  | *{{- range .Values.ingress.secrets }}   |       0 & 1          | {% for item_secrets in .Values.ingress.secrets }} |
+  ----------------------------------------------------------------------------------------------------------
+  | {{range $key, $value := ingress.annotations }}  | 2 & 1 | {% for $key, $value in ingress.annotations %}|
+  -----------------------------------------------------------------------------------------------------------
+  | {{- range $host := .Values.ingress.hosts }}  | 1 & 1 | {% for $host in .Values.ingress.hosts }}        |
+  ----------------------------------------------------------------------------------------------------------
+  | {{ range tuple "config1.toml" "config2.toml" "config3.toml" }} |0 & n |
+  								{% for tuple "config1.toml" "config2.toml" "config3.toml" %}
+*/
+const (
+	UseCaseDefault     RangeUseCaseType = iota //Unknown use cases
+	UseCaseNoVariables                         // *{{- range .Values.ingress.secrets }}
+	UseCaseKeyValue                            // {{range $key, $value := ingress.annotations }}
+	UseCaseSingleValue                         //{{- range $host := .Values.ingress.hosts }}
+	UseCaseTuple                               //range tuple "config1.toml" "config2.toml" "config3.toml" }}
+)
+
+func (r *RangeNode) writeTo(sb *strings.Builder) {
+	var rangeValues *map[string][]*helm.LogHelmReport
+	var dotValue = make(map[string][]*helm.LogHelmReport)
+	dotValue["."] = []*helm.LogHelmReport{}
+	var itemField string
+	removeBodyVariablePrefix := false
+
+	sb.WriteString("{% ")
+	/*-------------------------------------------------------------------------------------------------------
+	  | INPUT                                  | LHS(vars) & RHS(cmds) |  OUTPUT                              |
+	   --------------------------------------------------------------------------------------------------------
+	  | *{{- range .Values.ingress.secrets }}   |       0 & 1          | {% for item_secrets in .Values.ingress.secrets }} |
+	  ----------------------------------------------------------------------------------------------------------
+	  | {{range $key, $value := ingress.annotations }}  | 2 & 1 | {% for $key, $value in ingress.annotations %}|
+	  -----------------------------------------------------------------------------------------------------------
+	  | {{- range $host := .Values.ingress.hosts }}  | 1 & 1 | {% for $host in .Values.ingress.hosts }}        |
+	  ----------------------------------------------------------------------------------------------------------
+	  | {{ range tuple "config1.toml" "config2.toml" "config3.toml" }} |0 & n |
+									{% for tuple "config1.toml" "config2.toml" "config3.toml" %}
+	*/
+	//a) if you have zero variables and one command argument then {{- range .Values.ingress.secrets }}
+	////1. derive the item_name and prefix the variables under the cmds variable found  in values with $item_name
+	//r) if you have two variables then assume  you have key and value don't have to do anything
+	//c) if you have  one variable then
+	// 1. derive the item_name and prefix the variables under the cmds variable found  in values with $item_name
+	switch r.GetRangeUseCaseType() {
+	case UseCaseNoVariables:
+		{ //{{- range .Values.ingress.secrets }}
+			//extract item from single argument
+			sb.WriteString("for")
+			sb.WriteByte(' ')
+			ss := strings.Split(r.Pipe.Cmds[0].Args[0].String(), ".")
+			itemField = "item_" + ss[len(ss)-1]
+			sb.WriteString(itemField)
+			sb.WriteByte(' ')
+			sb.WriteString("in")
+			sb.WriteByte(' ')
+			r.Pipe.writeForTo(sb)
+			rangeValues, _ = helm.GetValues(r.Pipe.Cmds[0].Args[0].String())
+			logrus.Info("Attempting to prefix variables with loop variable,example: `value` becomes `item.value` for template", r.tr.Name)
+			//attempting for dot values
+			if rangeValues == nil {
+				logrus.Warnf("Failed to prefix variables with loop variable value for template %s", r.tr.Name)
+				logrus.Warnf("%s at position %d was not found in Helm chart's values: invalid path", r.Pipe.Cmds[0].Args[0].String(), r.Pos)
+				rangeValues = &dotValue
+			} else {
+				(*rangeValues)["."] = []*helm.LogHelmReport{}
+			}
+
+		}
+	case UseCaseKeyValue, UseCaseSingleValue:
+		{
+			sb.WriteString("for")
+			sb.WriteByte(' ')
+			r.RemoveVarPrefix("$")
+			r.Pipe.writeForTo(sb)
+			removeBodyVariablePrefix = true
+		}
+	case UseCaseTuple:
+		{
+			sb.WriteString("for")
+			sb.WriteByte(' ')
+			r.Pipe.writeForTo(sb)
+		}
+	default:
+		{
+			sb.WriteString("for ")
+			r.Pipe.writeForTo(sb)
+		}
+	}
+
+	sb.WriteString(" %}")
+	r.List.writeTo(sb)
+	// all the things if the conditional is true
+	//prefix  range variables with item
+	if rangeValues != nil {
+		helm.PreFixValuesWithItems(sb, itemField, rangeValues)
+		logrus.Infof("**************************************************************")
+		logrus.Info("       for loop variables replacement inside for loop : 	", r.tr.Name)
+		logrus.Infof("**************************************************************")
+		logrus.Infof("For loop: Following variables were prefixed with %s in template %s", itemField, r.tr.Name)
+		for k, v := range *rangeValues {
+			helm.PrintReportItems(v)
+			delete(*rangeValues, k)
+		}
+		logrus.Infof("**************************************************************")
+	}
+	// Clean $ prefixed variable
+	if removeBodyVariablePrefix {
+		helm.RemoveDollarPrefix(sb)
+	}
+
+	if r.ElseList != nil {
+		sb.WriteString("{% else %}")
+		r.ElseList.writeTo(sb)
+	}
+	sb.WriteString("{% endfor %}")
+}
+
+func (r *RangeNode) tree() *Tree {
+	return r.tr
+}
+
+func (r *RangeNode) Copy() Node {
+	return r.tr.newRange(r.Pos, r.Line, r.Pipe.CopyPipe(), r.List.CopyList(), r.ElseList.CopyList())
+}

--- a/internal/pkg/text/template/parse/range_pipe_node.go
+++ b/internal/pkg/text/template/parse/range_pipe_node.go
@@ -1,0 +1,91 @@
+package parse
+
+import "strings"
+
+// RangePipeNode holds an "range" pipeline (i.e., everything after "{{ range ").  IfPipeNode was abstracted from the
+// generic  PipeNode in order to hand tailor Jinja2 output, which varies greatly from other branch structures in the
+// Jinja2 template language.
+type RangePipeNode struct {
+	NodeType
+	Pos
+	tr       *Tree
+	Line     int
+	IsAssign bool
+	Decl     []*VariableNode
+	Cmds     []*CommandNode
+}
+
+func (p *RangePipeNode) append(command *CommandNode) {
+	p.Cmds = append(p.Cmds, command)
+}
+
+func (p *RangePipeNode) String() string {
+	var sb strings.Builder
+	p.writeTo(&sb)
+	return sb.String()
+}
+
+func (t *Tree) newRangePipeline(pos Pos, line int, vars []*VariableNode) *RangePipeNode {
+	return &RangePipeNode{tr: t, NodeType: NodePipeRange, Pos: pos, Line: line, Decl: vars}
+}
+
+func (p *RangePipeNode) writeTo(sb *strings.Builder) {
+	if len(p.Decl) > 0 {
+		for i, v := range p.Decl {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			v.writeTo(sb)
+		}
+		sb.WriteString(" := ")
+	}
+	for i, c := range p.Cmds {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		c.writeTo(sb)
+	}
+}
+
+func (p *RangePipeNode) tree() *Tree {
+	return p.tr
+}
+
+func (p *RangePipeNode) CopyPipe() *RangePipeNode {
+	if p == nil {
+		return p
+	}
+	vars := make([]*VariableNode, len(p.Decl))
+	for i, d := range p.Decl {
+		vars[i] = d.Copy().(*VariableNode)
+	}
+	n := p.tr.newRangePipeline(p.Pos, p.Line, vars)
+	n.IsAssign = p.IsAssign
+	for _, c := range p.Cmds {
+		n.append(c.Copy().(*CommandNode))
+	}
+	return n
+}
+
+func (p *RangePipeNode) Copy() Node {
+	return p.CopyPipe()
+}
+
+// writeFor is used used to convert `:=` to `in`
+func (p *RangePipeNode) writeForTo(sb *strings.Builder) {
+	if len(p.Decl) > 0 {
+		for i, v := range p.Decl {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			v.writeTo(sb)
+		}
+		sb.WriteString(" in ")
+	}
+	for i, c := range p.Cmds {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		c.writeTo(sb)
+	}
+}

--- a/internal/pkg/text/template/parse/testdata/basic_with/BasicWith.yml.j2
+++ b/internal/pkg/text/template/parse/testdata/basic_with/BasicWith.yml.j2
@@ -1,0 +1,5 @@
+{% with .Values.masterNode %}
+.vCPU
+{% else %}
+somePredeterminedText
+{% endwith %}

--- a/internal/pkg/text/template/parse/testdata/basic_with/Chart.yaml
+++ b/internal/pkg/text/template/parse/testdata/basic_with/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: basic_with
+version: 1.0.0
+appVersion: 1.0.0
+description: Contrived chart
+keywords:
+  - basic
+  - conditional
+  - basic helm chart
+home: http://127.0.0.1/
+icon: https://127.0.0.1/favicon.ico
+sources:
+  - https://127.0.0.1/basicconditional
+maintainers:
+  - name: none
+    email: none@127.0.0.1
+engine: gotpl

--- a/internal/pkg/text/template/parse/testdata/basic_with/templates/BasicWith.yml
+++ b/internal/pkg/text/template/parse/testdata/basic_with/templates/BasicWith.yml
@@ -1,0 +1,5 @@
+{{ with .Values.masterNode }}
+.vCPU
+{{ else }}
+somePredeterminedText
+{{ end }}

--- a/internal/pkg/text/template/parse/testdata/basic_with/values.yaml
+++ b/internal/pkg/text/template/parse/testdata/basic_with/values.yaml
@@ -1,0 +1,3 @@
+masterNode:
+  name: "masterNode"
+  vCPU: 4

--- a/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/NestedConditionalWithIfDefinition.yml.j2
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/NestedConditionalWithIfDefinition.yml.j2
@@ -15,3 +15,12 @@ condition1IsFalse
   {% endfor %}{% for key, value in .Values.metrics.serviceMonitor.selector %}
   {{ key }}: {{ value | quote }}{% endfor %}
 {% endif %}
+{% if something is defined %}
+  {{ .Values.something }}
+{% else %}
+{% if somethingElse is defined %}
+  {{ .Values.somethingElse }}
+{% else %}
+  default
+{% endif %}
+{% endif %}

--- a/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/templates/NestedConditionalWithIfDefinition.yml
+++ b/internal/pkg/text/template/parse/testdata/nested_conditional_with_if_definition/templates/NestedConditionalWithIfDefinition.yml
@@ -17,3 +17,12 @@ condition1IsFalse
   {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{ end }}
+{{ if .Values.something }}
+  {{ .Values.something }}
+{{ else }}
+{{ if .Values.somethingElse }}
+  {{ .Values.somethingElse }}
+{{ else }}
+  default
+{{ end }}
+{{ end }}

--- a/internal/pkg/text/template/parse/with_node.go
+++ b/internal/pkg/text/template/parse/with_node.go
@@ -1,0 +1,59 @@
+package parse
+
+import (
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+// WithNode is the representation of a "with" statement.  This is a tailored version of text/template's BranchNode.
+// The text/template package "if", "for" and "with" utilizing the BranchNode abstraction.  This makes sense, since the
+// types are all very similar in Go Templating, and they are all output in very similar manners.  However, Jinja2 has
+// greater requirements surrounding output of these Branch structures. This abstraction is introduced to handle the
+// "with" BranchNode.
+//
+// Currently, the implementation outputs go template code, as Ansible does not support the "with" block.  A warning
+// including the source line number is emitted to the user that a manual conversion is required.  In the future, this
+// should be improved to support a more automated form of conversion.
+type WithNode struct {
+	NodeType
+	Pos
+	tr       *Tree
+	Line     int           // The line number in the input. Deprecated: Kept for compatibility.
+	Pipe     *WithPipeNode // The *with* pipeline to be evaluated.
+	List     *ListNode     // What to execute if the value is non-empty.
+	ElseList *ListNode     // What to execute if the value is empty (nil if absent).
+}
+
+func (w *WithNode) String() string {
+	var sb strings.Builder
+	w.writeTo(&sb)
+	return sb.String()
+}
+
+func (w *WithNode) writeTo(sb *strings.Builder) {
+	// TODO:  This implementation will not work in Ansible.  This is not a regression;  no existing solution has
+	// handled with appropriately.
+	logrus.Warnf("\"with\" block on line %d outputting as in Go Template format;  manual conversion required",
+		w.Line)
+	sb.WriteString("{% with ")
+	w.Pipe.writeTo(sb)
+	sb.WriteString(" %}")
+	w.List.writeTo(sb)
+	if w.ElseList != nil {
+		sb.WriteString("{% else %}")
+		w.ElseList.writeTo(sb)
+	}
+	sb.WriteString("{% endwith %}")
+}
+
+func (t *Tree) newWith(pos Pos, line int, pipe *WithPipeNode, list, elseList *ListNode) *WithNode {
+	return &WithNode{tr: t, NodeType: NodeWith, Pos: pos, Line: line, Pipe: pipe, List: list, ElseList: elseList}
+}
+
+func (w *WithNode) Copy() Node {
+	return w.tr.newWith(w.Pos, w.Line, w.Pipe.CopyPipe(), w.List.CopyList(), w.ElseList.CopyList())
+}
+
+func (w *WithNode) tree() *Tree {
+	return w.tr
+}

--- a/internal/pkg/text/template/parse/with_pipe_node.go
+++ b/internal/pkg/text/template/parse/with_pipe_node.go
@@ -1,0 +1,72 @@
+package parse
+
+import "strings"
+
+// WithPipeNode holds a "with" pipeline (i.e., everything after "{{ with ").  IfPipeNode was abstracted from the generic
+// PipeNode in order to hand tailor Jinja2 output, which varies greatly from other branch structures in the Jinja2
+// template language.
+type WithPipeNode struct {
+	NodeType
+	Pos
+	tr       *Tree
+	Line     int
+	IsAssign bool
+	Decl     []*VariableNode
+	Cmds     []*CommandNode
+}
+
+func (p *WithPipeNode) append(command *CommandNode) {
+	p.Cmds = append(p.Cmds, command)
+}
+
+func (p *WithPipeNode) String() string {
+	var sb strings.Builder
+	p.writeTo(&sb)
+	return sb.String()
+}
+
+func (t *Tree) newWithPipeline(pos Pos, line int, vars []*VariableNode) *WithPipeNode {
+	return &WithPipeNode{tr: t, NodeType: NodePipeWith, Pos: pos, Line: line, Decl: vars}
+}
+
+func (p *WithPipeNode) writeTo(sb *strings.Builder) {
+	if len(p.Decl) > 0 {
+		for i, v := range p.Decl {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			v.writeTo(sb)
+		}
+		sb.WriteString(" := ")
+	}
+	for i, c := range p.Cmds {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		c.writeTo(sb)
+	}
+}
+
+func (p *WithPipeNode) tree() *Tree {
+	return p.tr
+}
+
+func (p *WithPipeNode) CopyPipe() *WithPipeNode {
+	if p == nil {
+		return p
+	}
+	vars := make([]*VariableNode, len(p.Decl))
+	for i, d := range p.Decl {
+		vars[i] = d.Copy().(*VariableNode)
+	}
+	n := p.tr.newWithPipeline(p.Pos, p.Line, vars)
+	n.IsAssign = p.IsAssign
+	for _, c := range p.Cmds {
+		n.append(c.Copy().(*CommandNode))
+	}
+	return n
+}
+
+func (p *WithPipeNode) Copy() Node {
+	return p.CopyPipe()
+}


### PR DESCRIPTION
Essentially, Helm Ansible Template Exporter is a partial cross compiler
which takes Go Template input and exports Jinja2 syntax.  This impl. is
focused on a Helm origination context, so there is additional context
information made available to the compiler.

Prior to this patch, the implementation had gotten messy.  This was in
part due to the fact that the original Abstract Syntax Tree (AST) had
been maintained from the Go Template engine parser.  That was fine for
a demo, but lacks long term vision since translation methods were
largely hacked into existing overloaded methods.  Overloaded methods
refers to the fact that several Nodes were used for overloaded
functionality.  Namely, the BranchNode in the Go "text/template"
package is used to represent "if", "range" and "with" constructs.  Each
of these constructs can be translated into Jinja2, but each requires a
different translation path.  Thus, this patch removes BranchNode and
abstracts the following:

* IfNode:  Represents an "if" statement.  Has the knowledge to output
  "if" in a Jinja2 compliant manner.
* RangeNode:  Represents a "range" statement.  Has the functionality to
  convert Go "range" into a matching Jinja2 "for" statement.
* WithNode:  Represents a "with" statement.  With conversion is not
  supported in this version, so an appropriate warning is emitted to
  the user.

Additionally, PipeNode (canonically referred to as "pipeline" in the
original code) was special cased for these each "if", "range" and
"with" context.  This was done as the common ancestral parent of
"IfNode", "RangeNode" and "WithNode" is the "ActionNode", and in order
to appropriately convey context down the tree, each PipeNode needed
some special cased functionality.

An "IfCommandNode" was abstracted since conditional Commands are
much different than all other CommandNodes.  The primary difference is
that IfCommandNode's require a heuristic to infer the appropriate
translation into Jinja2.  Since this information was purely unique to
"IfNode", it was modified to have its own implementation so as to not
pollute other areas of code.

This change may appear rather large.  In fact, a lot of the code is
purely copy and paste given that many of the nodes do implement similar
functionality.  However, the differences in translation mechanism
were large enough to modify the AST in order to more cleanly render
Jinja2 output.

Lastly, the ugly j2Context argument was removed from the
Node.writeTo(...) interface.  IsConditional is now obvious since
conditionals have their own AST Node implementation (IfNode).
IsFunc is propagated from the parser through the FieldNode to
the underlying CommandNode.  PipeNodeCount was made a simple optional
property of the CommandNode abstraction.  This is much cleaner than
passing breadcrumbs across interfaces.

These changes were tested with the existing tests.  Additionally, they
were spot checked against the "nginx" and "redis" charts for
correctness.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>