### PR TITLE
Include minimum versions for Runtime Dependencies #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ make clean
 #### Runtime Dependencies
 
 Helm Ansible Template Exporter requires [ansible-galaxy](https://galaxy.ansible.com/) to initialize exported roles.
-Additionally, ansible-galaxy must be included in the $PATH.  If you utilize the "generateFilters" flag, then a Go
-compiler must be installed.
+At a minimum, we suggest using Ansible Galaxy version `2.9.6`.  Additionally, `ansible-galaxy` must be included in your
+`$PATH`.
+
+If you utilize the `-generateFilters` flag, then a GoLang 1.14 compiler must be installed.
 
 #### Run Instructions
 


### PR DESCRIPTION
Adjusts README.md to include minimum version requirements for runtime
dependencies.  This was initially omitted as the offering was supposed
to be containerized, which would hide many of these details.  For now,
just be transparent about what is there and what is required.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>