### PR TITLE
Add nil pointer protection to getTargetedReplacementKeys()

### DIFF
--- a/internal/pkg/convert/convert.go
+++ b/internal/pkg/convert/convert.go
@@ -444,10 +444,12 @@ func getTargetedReplacementKeysRecursive(input *map[string]interface{}, keys *ma
 
 // Build up a map of Ansible keys in defaults/main.yaml that should be converted to snake_case.
 func getTargetedReplacementKeys(chartClient *helm.HelmChartClient) *map[string]string {
-	raw, _ := chartutil.ReadValues([]byte(chartClient.Chart.Values.Raw))
-	chartMap := raw.AsMap()
 	keys := map[string]string{}
-	getTargetedReplacementKeysRecursive(&chartMap, &keys)
+	if chartClient.Chart.Values!=nil{
+		raw, _ := chartutil.ReadValues([]byte(chartClient.Chart.Values.Raw))
+		chartMap := raw.AsMap()
+		getTargetedReplacementKeysRecursive(&chartMap, &keys)
+	}
 	return &keys
 }
 


### PR DESCRIPTION
Add nil pointer protection to getTargetedReplacementKeys(). 

The current code will panic if a chart does not have values.yaml defined

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x143a1c1]

goroutine 1 [running]:
github.com/redhat-nfvpe/helm-ansible-template-exporter/internal/pkg/convert.getTargetedReplacementKeys(0xc0001f9cb0, 0x0)

...
```